### PR TITLE
fix(68): Dockerfile 用 npm 镜像源安装 pnpm，替代卡顿的 corepack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 # Stage 1: base
 FROM node:20-alpine AS base
-ENV PNPM_HOME="/home/node/.local/share/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable \
-  && corepack prepare pnpm@9.15.0 --activate \
+RUN npm install -g pnpm@9.15.0 --registry=https://registry.npmmirror.com \
+  && pnpm config set registry https://registry.npmmirror.com \
   && apk add --no-cache curl
 WORKDIR /app
 


### PR DESCRIPTION
- corepack prepare 从 GitHub 下载 pnpm 二进制，国内服务器超时
- 改为 npm install -g pnpm --registry=https://registry.npmmirror.com
- 恢复 pnpm config set registry 使用国内镜像源