### PR TITLE
fix(68): docker-compose 移除 nginx 编排，next 暴露 3000 端口

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,12 @@
 services:
-  nginx:
-    image: nginx:alpine
-    ports:
-      - "80:80"
-      - "443:443"
-    volumes:
-      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
-    depends_on:
-      - next
-    restart: unless-stopped
-
   next:
     build:
       context: .
       target: runner-next
     env_file:
       - .env
+    ports:
+      - "3000:3000"
     environment:
       - NEST_API_URL=http://nest:3200/v2
     depends_on:


### PR DESCRIPTION
服务器已有外部 nginx，不需要容器内编排。next 映射 3000:3000 供外部 nginx 代理。