### PR TITLE
fix(68): 移除不存在的 docs/hooks package.json COPY，仅保留已跟踪的包

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,6 @@ COPY packages/wuh.site.next/package.json packages/wuh.site.next/
 COPY packages/wuh.site.nest/package.json packages/wuh.site.nest/
 COPY packages/components/package.json packages/components/
 COPY packages/config/package.json packages/config/
-COPY packages/docs/package.json packages/docs/
-COPY packages/hooks/package.json packages/hooks/
 COPY packages/shared-contracts/package.json packages/shared-contracts/
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
   pnpm install --no-frozen-lockfile


### PR DESCRIPTION
packages/docs 和 packages/hooks 无 package.json，不是 workspace 包