### PR TITLE
fix(68): builder 阶段改用 WORKDIR + npx 直接构建，绕过 pnpm --filter 目录问题

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,14 @@ COPY packages ./
 
 # Stage 3: builder-next (incremental build with .next/cache)
 FROM deps AS builder-next
+WORKDIR /app/packages/wuh.site.next
 RUN --mount=type=cache,target=/app/packages/wuh.site.next/.next/cache \
-  pnpm run build:next
+  npx next build
 
 # Stage 4: builder-nest
 FROM deps AS builder-nest
-RUN pnpm run build:nest
+WORKDIR /app/packages/wuh.site.nest
+RUN npx nest build
 
 # Stage 5: runner-next
 FROM base AS runner-next


### PR DESCRIPTION
pnpm --filter 在 Docker 中构建时工作目录解析异常，导致 next build 找不到 app/、nest build 找不到 tsconfig.json