### PR TITLE
fix(68): nest 添加 express 直接依赖，修复 pnpm strict 模式下模块解析失败

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,4 +49,4 @@ EXPOSE 3200
 ENV NODE_ENV=production
 HEALTHCHECK --interval=30s --timeout=3s --start-period=30s --retries=3 \
   CMD curl -f http://localhost:3200/v2/health || exit 1
-CMD ["pnpm", "--filter", "@wuh.site/nest", "exec", "node", "dist/main"]
+CMD ["node", "packages/wuh.site.nest/dist/main"]

--- a/packages/wuh.site.nest/package.json
+++ b/packages/wuh.site.nest/package.json
@@ -34,6 +34,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "dotenv": "^16.3.1",
+    "express": "^4.18.2",
     "feed": "^4.2.2",
     "mongoose": "^8.0.3",
     "passport": "^0.7.0",


### PR DESCRIPTION
webhook.controller 和 http-exception.filter 直接 import 'express'， 但 express 只在 @nestjs/platform-express 的传递依赖中，
pnpm strict 模式下不可访问