### PR TITLE
refactor: 重设计 404/500 页面为 editorial 风格，与网站视觉统一

### DIFF
--- a/openspec/changes/archive/20260510_P_redesign-error-pages/.openspec.yaml
+++ b/openspec/changes/archive/20260510_P_redesign-error-pages/.openspec.yaml
@@ -1,0 +1,5 @@
+project: 重新设计404/500页面
+change: redesign-error-pages
+date: 2026-05-10
+type: P
+status: applied

--- a/openspec/changes/archive/20260510_P_redesign-error-pages/design.md
+++ b/openspec/changes/archive/20260510_P_redesign-error-pages/design.md
@@ -1,0 +1,51 @@
+# 设计文档
+
+## 架构对比
+
+### 之前
+
+```
+not-found.tsx
+  ├── createGlobalStyle — 重复设置 body 样式
+  ├── Root (flex centering)
+  └── Result (status='404')
+        ├── Card (border + shadow + grid 布局)
+        ├── Status badge (danger color pill)
+        ├── Title / Description
+        ├── Link pills
+        └── Button actions
+
+error.tsx
+  └── Result (status='500')
+        └── 同上 Card 布局
+```
+
+### 之后
+
+```
+not-found.tsx
+  └── 与首页一致的开放布局
+        ├── 大号状态数字 (404/500) — typography 驱动
+        ├── 标题 + 描述文字
+        └── 操作按钮组
+
+error.tsx
+  └── 同 not-found.tsx 的布局
+        └── 额外: reset() 重试按钮
+```
+
+## 视觉方向
+
+- **无边卡** — 移除 `border` + `box-shadow` + `background` card 容器
+- **Typography 驱动** — 大号状态数字作为视觉焦点，标题/描述文字层次分明
+- **酒红氛围** — 使用 `var(--primary-color)` 点缀状态数字
+- **居中布局** — 与首页一致的 `min-height: 70vh` 垂直居中
+- **共享样式组件** — 两个页面复用同一套样式
+
+## 涉及文件
+
+| 文件 | 变更类型 | 说明 |
+|------|----------|------|
+| `app/not-found.tsx` | 重写 | 移除 Result + GlobalLayout，改为 editorial 风格 |
+| `app/error.tsx` | 重写 | 同上布局，保留 reset() |
+| `app/post/[number]/error.tsx` | 重写 | 同上布局，博客相关文案 |

--- a/openspec/changes/archive/20260510_P_redesign-error-pages/proposal.md
+++ b/openspec/changes/archive/20260510_P_redesign-error-pages/proposal.md
@@ -1,0 +1,13 @@
+# 重新设计404/500页面
+
+## What
+
+重新设计博客的 404 (not-found.tsx) 和 500 (error.tsx) 错误页面，使其视觉风格与网站整体保持一致。当前这两个页面使用通用 UI 库风格的 Result 组件（card + border + status badge），与网站的酒红 editorial 风格不搭配。
+
+## Why
+
+1. **Result 组件的 card/border/badge 风格偏通用 UI 库** — 与首页、博客列表、文章详情页的开放布局、无边框设计语言不统一
+2. **404 页面有自定义 GlobalLayout** — 重复设置 body 样式，与根 layout 冲突
+3. **视觉脱节** — 用户从首页/博客页跳转到 404/500 时，明显感觉进入了不同风格的页面
+
+重新设计后，错误页将采用网站统一的 typography 驱动、无边卡、酒红氛围的 editorial 风格。

--- a/openspec/changes/archive/20260510_P_redesign-error-pages/specs/redesign-error-pages/spec.md
+++ b/openspec/changes/archive/20260510_P_redesign-error-pages/specs/redesign-error-pages/spec.md
@@ -1,0 +1,24 @@
+# 重新设计404/500页面
+
+## R1 — 404 页面 editorial 风格
+
+移除 Result 组件和 GlobalLayout，改为 typography 驱动的开放布局：
+- 大号 "404" 数字作为视觉焦点，使用 primary-color 点缀
+- 标题 + 描述文字层次分明
+- 操作按钮（返回首页 + 知识库链接）
+- 无边卡、无阴影，融入网站整体氛围
+
+## R2 — 500 页面 editorial 风格
+
+与 404 页面保持一致的布局，额外提供 reset() 重试按钮。post/[number] 下的 500 页面使用博客相关文案。
+
+## R3 — 移除冗余样式
+
+删除 not-found.tsx 中的 `createGlobalStyle` body 样式覆盖，信任根 layout 的全局样式。
+
+## R4 — 保留现有功能
+
+以下功能不受影响：
+- 404 页面：返回首页、GitHub/语雀/微信公众号链接
+- 500 页面：重试按钮、返回首页、GitHub/语雀链接
+- post/[number]/error.tsx：GitHub/知识库链接

--- a/openspec/changes/archive/20260510_P_redesign-error-pages/tasks.md
+++ b/openspec/changes/archive/20260510_P_redesign-error-pages/tasks.md
@@ -1,0 +1,22 @@
+# 任务拆分
+
+## Phase 1 — 重写 404 页面
+
+- [x] T1: 重写 `app/not-found.tsx` — 移除 Result 组件和 GlobalLayout，改为 typography 驱动的 editorial 风格布局
+  - 涉及文件: `app/not-found.tsx`
+  - 预计耗时: 30min
+
+## Phase 2 — 重写 500 页面
+
+- [x] T2: 重写 `app/error.tsx` — 与 not-found.tsx 保持一致的布局，保留 reset() 重试按钮
+  - 涉及文件: `app/error.tsx`
+  - 预计耗时: 20min
+
+- [x] T3: 重写 `app/post/[number]/error.tsx` — 同布局，博客相关文案
+  - 涉及文件: `app/post/[number]/error.tsx`
+  - 预计耗时: 15min
+
+## Phase 3 — 验证
+
+- [ ] T4: TypeScript 类型检查通过
+- [ ] T5: 本地 dev server 手动验证 404/500 页面风格与首页一致

--- a/openspec/specs/redesign-error-pages/spec.md
+++ b/openspec/specs/redesign-error-pages/spec.md
@@ -1,0 +1,24 @@
+# 重新设计404/500页面
+
+## R1 — 404 页面 editorial 风格
+
+移除 Result 组件和 GlobalLayout，改为 typography 驱动的开放布局：
+- 大号 "404" 数字作为视觉焦点，使用 primary-color 点缀
+- 标题 + 描述文字层次分明
+- 操作按钮（返回首页 + 知识库链接）
+- 无边卡、无阴影，融入网站整体氛围
+
+## R2 — 500 页面 editorial 风格
+
+与 404 页面保持一致的布局，额外提供 reset() 重试按钮。post/[number] 下的 500 页面使用博客相关文案。
+
+## R3 — 移除冗余样式
+
+删除 not-found.tsx 中的 `createGlobalStyle` body 样式覆盖，信任根 layout 的全局样式。
+
+## R4 — 保留现有功能
+
+以下功能不受影响：
+- 404 页面：返回首页、GitHub/语雀/微信公众号链接
+- 500 页面：重试按钮、返回首页、GitHub/语雀链接
+- post/[number]/error.tsx：GitHub/知识库链接

--- a/packages/wuh.site.next/app/components/ErrorPage.tsx
+++ b/packages/wuh.site.next/app/components/ErrorPage.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import styled from 'styled-components'
+
+type ErrorPageProps = {
+  code: '404' | '500'
+  title: string
+  description: ReactNode
+  children?: ReactNode
+}
+
+const Root = styled.div`
+  flex: 1;
+  min-height: 70vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 64px 24px;
+  font-family: var(--font-geist-sans);
+`
+
+const StatusCode = styled.p`
+  margin: 0;
+  font-size: clamp(96px, 14vw, 160px);
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: -0.04em;
+  color: var(--primary-color);
+  opacity: 0.55;
+  user-select: none;
+`
+
+const Title = styled.h1`
+  margin: var(--space-lg) 0 0;
+  font-size: var(--font-size-xl);
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: -0.02em;
+`
+
+const Description = styled.p`
+  margin: var(--space-md) 0 0;
+  font-size: var(--font-size-md);
+  color: var(--text-secondary);
+  line-height: 1.7;
+  text-align: center;
+  text-wrap: pretty;
+  max-width: 480px;
+`
+
+const Actions = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  margin-top: var(--space-2xl);
+  justify-content: center;
+`
+
+export default function ErrorPage({ code, title, description, children }: ErrorPageProps) {
+  return (
+    <Root>
+      <StatusCode>{code}</StatusCode>
+      <Title>{title}</Title>
+      <Description>{description}</Description>
+      {children ? <Actions>{children}</Actions> : null}
+    </Root>
+  )
+}

--- a/packages/wuh.site.next/app/error.tsx
+++ b/packages/wuh.site.next/app/error.tsx
@@ -1,24 +1,19 @@
 'use client'
 
-import Result from '@wuh.site/components/result'
 import Button from '@wuh.site/components/button'
+import ErrorPage from './components/ErrorPage'
 
 export default function Error({ reset }: { reset: () => void }) {
   return (
-    <Result
-      status='500'
+    <ErrorPage
+      code='500'
       title='页面出现异常'
-      description='我们正在修复这个问题，你可以稍后再试或先前往其他平台查看内容。'
-      links={[
-        { label: 'GitHub 项目', href: 'https://github.com/stack-wuh/x.wuh.site', target: '_blank' },
-        { label: '语雀文档', href: 'https://www.yuque.com/shadow.wu/gb3x29', target: '_blank' }
-      ]}
-      extra={(
-        <>
-          <Button onClick={() => reset()} variant='filled' color='primary'>重试</Button>
-          <Button href='/' variant='outlined'>返回首页</Button>
-        </>
-      )}
-    />
+      description={<>我们正在修复这个问题，<br />你可以稍后再试或先前往其他平台查看内容。</>}
+    >
+      <Button onClick={() => reset()} variant='filled' color='primary'>重试</Button>
+      <Button href='/' variant='outlined'>返回首页</Button>
+      <Button href='https://github.com/stack-wuh/x.wuh.site' target='_blank' rel='noopener noreferrer' variant='text'>GitHub 项目</Button>
+      <Button href='https://www.yuque.com/shadow.wu/gb3x29' target='_blank' rel='noopener noreferrer' variant='text'>语雀文档</Button>
+    </ErrorPage>
   )
 }

--- a/packages/wuh.site.next/app/not-found.tsx
+++ b/packages/wuh.site.next/app/not-found.tsx
@@ -1,40 +1,7 @@
 'use client'
 
-import styled, { createGlobalStyle } from 'styled-components'
-import Result from '@wuh.site/components/result'
 import Button from '@wuh.site/components/button'
-import Image from '@wuh.site/components/image'
-
-const GlobalLayout = createGlobalStyle`
-  body {
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-    background-color: var(--background-color);
-  }
-`
-
-const Root = styled.div`
-  flex: 1;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-family: var(--font-geist-sans);
-  padding: 32px 24px;
-`
-
-const ResultWrap = styled.div`
-  width: 100%;
-  display: flex;
-  justify-content: center;
-`
-
-const ResultBlock = styled(Result)`
-  min-height: auto;
-  padding: 0;
-`
+import ErrorPage from './components/ErrorPage'
 
 const links = [
   { label: 'GitHub 项目', href: 'https://github.com/stack-wuh/x.wuh.site', target: '_blank' },
@@ -42,39 +9,22 @@ const links = [
   { label: '微信公众号：进阶的前端工程师' }
 ]
 
-const LogoIcon = () => (
-  <Image
-    src='/logo.svg'
-    alt='wuh.site.logo'
-    width={32}
-    height={20}
-    inline
-    showSkeleton={false}
-    appearance='plain'
-  />
-)
-
 export default function NotFound() {
   return (
-    <>
-      <GlobalLayout />
-      <Root>
-        <ResultWrap>
-          <ResultBlock
-            status='404'
-            icon={<LogoIcon />}
-            title='空空如也~~'
-            description='你访问的页面可能已被移动或删除，建议前往以下入口继续阅读。'
-            links={links}
-            extra={(
-              <>
-                <Button href='/' variant='filled' color='primary'>返回首页</Button>
-                <Button href='https://stack-wuh.github.io/blog/' target='_blank' rel='noopener noreferrer' variant='outlined'>知识库</Button>
-              </>
-            )}
-          />
-        </ResultWrap>
-      </Root>
-    </>
+    <ErrorPage
+      code='404'
+      title='空空如也~~'
+      description={<>你访问的页面可能已被移动或删除，<br />建议前往以下入口继续阅读。</>}
+    >
+      <Button href='/' variant='filled' color='primary'>返回首页</Button>
+      <Button href='https://stack-wuh.github.io/blog/' target='_blank' rel='noopener noreferrer' variant='outlined'>知识库</Button>
+      {links.map((link) =>
+        link.href ? (
+          <Button key={link.label} href={link.href} target={link.target} rel='noopener noreferrer' variant='text'>{link.label}</Button>
+        ) : (
+          <Button key={link.label} disabled variant='text'>{link.label}</Button>
+        )
+      )}
+    </ErrorPage>
   )
 }

--- a/packages/wuh.site.next/app/post/[number]/error.tsx
+++ b/packages/wuh.site.next/app/post/[number]/error.tsx
@@ -1,21 +1,18 @@
 'use client'
 
-import Result from '@wuh.site/components/result'
 import Button from '@wuh.site/components/button'
+import ErrorPage from '../../components/ErrorPage'
 
-export default function Error() {
+export default function PostError() {
   return (
-    <Result
-      status='500'
+    <ErrorPage
+      code='500'
       title='文章加载失败'
-      description='当前文章暂时无法加载，你可以前往 GitHub 或知识库继续阅读。'
-      links={[
-        { label: 'GitHub 博客', href: 'https://github.com/stack-wuh/blog/issues', target: '_blank' },
-        { label: '知识库', href: 'https://stack-wuh.github.io/blog/', target: '_blank' }
-      ]}
-      extra={(
-        <Button href='/' variant='outlined'>返回首页</Button>
-      )}
-    />
+      description={<>当前文章暂时无法加载，<br />你可以前往 GitHub 或知识库继续阅读。</>}
+    >
+      <Button href='/' variant='outlined'>返回首页</Button>
+      <Button href='https://github.com/stack-wuh/blog/issues' target='_blank' rel='noopener noreferrer' variant='text'>GitHub 博客</Button>
+      <Button href='https://stack-wuh.github.io/blog/' target='_blank' rel='noopener noreferrer' variant='text'>知识库</Button>
+    </ErrorPage>
   )
 }


### PR DESCRIPTION
移除通用 UI 库风格的 Result 组件（card+border+badge），改为 typography 驱动的开放布局：大号状态数字 + 手动换行描述 + 按钮组。新增共享 ErrorPage
组件，三个错误页复用。