### PR TITLE
fix(deploy): 修复磁盘爆满和 nest 运行时依赖问题

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -20,6 +20,4 @@ jobs:
             git checkout main
             git reset --hard origin/main
             git clean -fd
-            ./scripts/deploy-docker.sh stop || true
-            ./scripts/deploy-docker.sh build
-            ./scripts/deploy-docker.sh run
+            ./scripts/deploy-docker.sh restart

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,20 +26,13 @@ RUN --mount=type=cache,target=/app/packages/wuh.site.next/.next/cache \
 FROM deps AS builder-nest
 RUN pnpm run build:nest
 
-# Stage 5: prod-deps — production-only node_modules (much smaller)
-FROM base AS prod-deps
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
-COPY packages/wuh.site.next/package.json packages/wuh.site.next/
-COPY packages/wuh.site.nest/package.json packages/wuh.site.nest/
-COPY packages/components/package.json packages/components/
-COPY packages/config/package.json packages/config/
-COPY packages/shared-contracts/package.json packages/shared-contracts/
-RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
-  pnpm install --prod --no-frozen-lockfile --ignore-scripts
+# Stage 5: deps-pruned — strip devDependencies from full deps (keeps workspace packages)
+FROM deps AS deps-pruned
+RUN pnpm prune --prod --ignore-scripts
 
 # Stage 6: runner-next
 FROM base AS runner-next
-COPY --from=prod-deps /app/node_modules ./node_modules
+COPY --from=deps-pruned /app/node_modules ./node_modules
 COPY --from=deps /app/packages ./packages
 COPY --from=builder-next /app/packages/wuh.site.next/dist ./packages/wuh.site.next/dist
 COPY package.json pnpm-workspace.yaml ./
@@ -52,7 +45,7 @@ CMD ["pnpm", "run", "start:next"]
 
 # Stage 7: runner-nest
 FROM base AS runner-nest
-COPY --from=prod-deps /app/node_modules ./node_modules
+COPY --from=deps-pruned /app/node_modules ./node_modules
 COPY --from=deps /app/packages ./packages
 COPY --from=builder-nest /app/packages/wuh.site.nest/dist ./packages/wuh.site.nest/dist
 COPY package.json pnpm-workspace.yaml ./

--- a/scripts/deploy-docker.sh
+++ b/scripts/deploy-docker.sh
@@ -11,48 +11,93 @@ Commands:
   build    Build all Docker images via docker compose
   run      Start all services (docker compose up -d)
   stop     Stop and remove all services
+  restart  Stop → build → clean → run (full deploy cycle)
   push     Push images to registry (docker compose push)
-  clean    Prune Docker buildx cache (frees disk space)
+  clean    Remove dangling images + old build cache (frees disk space)
   logs     Tail logs from all services
   shell    Launch an interactive shell inside a service
   help     Show this message
 USAGE
 }
 
+# Remove old images (not the ones currently referenced by containers)
+prune_old_images() {
+  echo "🧹 Removing dangling images"
+  docker image prune --force 2>/dev/null || true
+}
+
+# Remove build cache older than 72h
+prune_old_cache() {
+  echo "🧹 Removing build cache older than 72h"
+  docker builder prune --filter "until=72h" --force 2>/dev/null || true
+}
+
+# Aggressive cleanup — use when disk is full
+prune_all_cache() {
+  echo "🧹 Full cache cleanup"
+  docker builder prune --all --force 2>/dev/null || true
+}
+
 case "${1:-help}" in
   build)
     echo "🔧 Building all services"
     docker compose build
+    prune_old_images
     ;;
-  clean)
-    echo "🧹 Pruning stale Docker buildx cache (keep last 24h)"
-    docker buildx prune --filter "until=24h" --force 2>/dev/null || true
-    echo "✅ Build cache cleaned"
-    ;;
+
   run)
     echo "🐳 Starting all services"
     docker compose up -d
     ;;
+
   stop)
     echo "🛑 Stopping all services"
     docker compose down
     ;;
+
+  restart)
+    echo "🔄 Full deploy cycle"
+    docker compose down 2>/dev/null || true
+    docker compose build
+    prune_old_images
+    docker compose up -d
+    ;;
+
   push)
     echo "📤 Pushing images"
     docker compose push
     ;;
+
+  clean)
+    echo "🧹 Cleaning Docker disk usage"
+    prune_old_images
+    prune_old_cache
+    echo "✅ Done"
+    ;;
+
+  clean-all)
+    echo "🧹 Aggressive Docker cleanup"
+    docker compose down 2>/dev/null || true
+    docker image prune --force 2>/dev/null || true
+    prune_all_cache
+    echo "✅ Done"
+    ;;
+
   logs)
     echo "📋 Tailing logs"
     docker compose logs -f
     ;;
+
   shell)
     SERVICE=${2:-next}
     echo "🧪 Opening shell in $SERVICE"
     docker compose exec "$SERVICE" /bin/sh
     ;;
+
   help|--help|-h)
     usage
     ;;
+
   *)
     echo "Unknown command: $1" >&2
     usage


### PR DESCRIPTION
- deps-pruned 基于 deps 用 pnpm prune --prod 裁剪，确保 workspace 包不被误删
- 新增 restart 命令：stop → build → prune → up，每次部署自动清理旧镜像
- clean-all 命令用于激进清理
- CI/CD 简化为重启命令（每次部署自动清理 dangling images）