### PR TITLE
ci: 构建失败时暴露完整错误日志

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -15,9 +15,16 @@ jobs:
           username: ${{ secrets.SERVER_USER }}
           password: ${{ secrets.SERVER_PASSWORD }}
           script: |
+            set -e
             cd /github/x.wuh.site
             git fetch origin main
             git checkout main
             git reset --hard origin/main
             git clean -fd
-            ./scripts/deploy-docker.sh restart
+            ./scripts/deploy-docker.sh restart 2>&1 | tee /tmp/deploy.log
+            exit_code=${PIPESTATUS[0]}
+            if [ $exit_code -ne 0 ]; then
+              echo "::error::构建失败，最后 80 行日志："
+              tail -80 /tmp/deploy.log
+              exit $exit_code
+            fi

--- a/scripts/deploy-docker.sh
+++ b/scripts/deploy-docker.sh
@@ -41,7 +41,7 @@ prune_all_cache() {
 case "${1:-help}" in
   build)
     echo "🔧 Building all services"
-    docker compose build
+    docker compose build --progress=plain
     prune_old_images
     ;;
 
@@ -58,7 +58,7 @@ case "${1:-help}" in
   restart)
     echo "🔄 Full deploy cycle"
     docker compose down 2>/dev/null || true
-    docker compose build
+    docker compose build --progress=plain
     prune_old_images
     docker compose up -d
     ;;


### PR DESCRIPTION
- docker compose build 加 --progress=plain 去掉动画，逐行输出
- CI/CD 构建失败时 tee 捕获日志并打印最后 80 行