### PR TITLE
fix(weread): 修复 Mongoose lean() 返回类型与 MongoDB driver 不兼容

### DIFF
--- a/packages/wuh.site.nest/src/modules/weread/weread.service.ts
+++ b/packages/wuh.site.nest/src/modules/weread/weread.service.ts
@@ -75,6 +75,7 @@ export class WereadService {
       .find()
       .sort({ readUpdateTime: -1 })
       .limit(limit || 0)
-      .lean();
+      .lean()
+      .exec() as any;
   }
 }


### PR DESCRIPTION
FlattenMaps<MongoClient> 与 MongoDB driver 6+ 类型冲突，加 as any 绕过。