### PR TITLE
fix: 移除 emitDeclarationOnly，shared-contracts 需产出 JS 供 NestJS 运行时引用 Us…

### DIFF
--- a/packages/shared-contracts/tsconfig.build.json
+++ b/packages/shared-contracts/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "declaration": true,
-    "emitDeclarationOnly": true,
     "outDir": "dist",
     "composite": true
   },


### PR DESCRIPTION
…erRole 枚举