### PR TITLE
feat(rss): 修复 RSS feed 链接格式 + 前端订阅入口

### DIFF
--- a/openspec/INDEX.md
+++ b/openspec/INDEX.md
@@ -13,6 +13,11 @@
 - **需求:** Paginated response format, Post not found returns 404, Query parameter type coercion, Labels comma-separated, findAll returns PaginatedResult, Post detail includes prev/next adjacent posts
 - **路径:** `openspec/specs/content-api/spec.md`
 
+## rss — RSS 订阅
+- **关键词:** RSS, feed, 订阅, XML, 自动发现
+- **需求:** RSS feed URL 格式, RSS 仅输出已发布内容, 前端 RSS 自动发现
+- **路径:** `openspec/specs/rss/spec.md`
+
 ## seo — SEO 优化
 - **关键词:** SEO, Open Graph, Twitter Card, JSON-LD, canonical, 结构化数据, URL slug
 - **需求:** 全站 Open Graph 标签, Twitter Card 标签, 差异化 description, JSON-LD BlogPosting, canonical URL, 博客 URL 包含标题 slug, 旧 URL 格式向后兼容

--- a/openspec/changes/archive/20260628_P_rss_fix_and_entry/.openspec.yaml
+++ b/openspec/changes/archive/20260628_P_rss_fix_and_entry/.openspec.yaml
@@ -1,0 +1,5 @@
+project: x.wuh.site
+change: rss-fix-and-entry
+date: 2026-06-28
+type: P
+status: proposed

--- a/openspec/changes/archive/20260628_P_rss_fix_and_entry/design.md
+++ b/openspec/changes/archive/20260628_P_rss_fix_and_entry/design.md
@@ -1,0 +1,30 @@
+# 设计文档
+
+## rss.service.ts 修复
+
+```ts
+// 修复前
+link: `https://wuh.site/posts/${content.metadata?.slug || content.number}`
+
+// 修复后
+link: `https://wuh.site/post/${content.number}-${toSlug(content.title)}`
+
+// 新增 state 过滤
+state: 'open'
+```
+
+## layout.tsx <head> RSS link
+
+```tsx
+<link rel="alternate" type="application/rss+xml" title="wuh.site RSS" href="https://wuh.site/v2/rss.xml" />
+```
+
+## footer.tsx RSS 入口
+
+在页脚加 RSS 订阅链接。
+
+## 影响分析
+
+- **新增依赖:** 无
+- **破坏性变更:** 无
+- **向后兼容:** 旧 RSS URL 不变

--- a/openspec/changes/archive/20260628_P_rss_fix_and_entry/proposal.md
+++ b/openspec/changes/archive/20260628_P_rss_fix_and_entry/proposal.md
@@ -1,0 +1,25 @@
+# RSS 修复 + 前端订阅入口
+
+## 背景
+
+RSS 模块已存在（`/v2/rss.xml`），但有两处 Bug + 前端没有入口：
+
+1. 链接格式是 `/posts/slug` 而不是当前的 `/post/123-标题slug`
+2. 没过滤 `state`，可能输出 closed issue
+
+## 目标
+
+- 修复链接格式、加 state 过滤
+- 前端 `<head>` 加 RSS `<link>` 标签（搜索引擎和 RSS 阅读器自动发现）
+- footer 加 RSS 订阅入口
+
+## 非目标
+
+- 不新增定时同步
+- 不新增依赖
+
+## 影响范围
+
+- `packages/wuh.site.nest/src/modules/rss/rss.service.ts` — 修复链接 + state 过滤
+- `packages/wuh.site.next/app/layout.tsx` — <head> RSS <link>
+- `packages/components/layout/footer.tsx` — RSS 订阅入口

--- a/openspec/changes/archive/20260628_P_rss_fix_and_entry/specs/rss/spec.md
+++ b/openspec/changes/archive/20260628_P_rss_fix_and_entry/specs/rss/spec.md
@@ -1,0 +1,22 @@
+# RSS
+
+## MODIFIED
+
+### Requirement: RSS feed URL 格式
+- **GIVEN** 博客详情页链接格式为 `/post/<number>-<title-slug>`
+- **WHEN** 生成 RSS feed
+- **THEN** item link 格式为 `https://wuh.site/post/<number>-<title-slug>`
+- **AND** 不再使用 `/posts/<slug>` 旧格式
+
+### Requirement: RSS 仅输出已发布内容
+- **GIVEN** 数据库中存在 open 和 closed 的 Issue
+- **WHEN** 生成 RSS feed
+- **THEN** 仅查询 `state: 'open'` 的内容
+
+## ADDED
+
+### Requirement: 前端 RSS 自动发现
+- **GIVEN** 任意页面
+- **WHEN** 浏览器或 RSS 阅读器访问
+- **THEN** `<head>` 包含 `<link rel="alternate" type="application/rss+xml" title="wuh.site RSS" href="https://wuh.site/v2/rss.xml">`
+- **AND** 页脚有 RSS 订阅入口链接

--- a/openspec/changes/archive/20260628_P_rss_fix_and_entry/tasks.md
+++ b/openspec/changes/archive/20260628_P_rss_fix_and_entry/tasks.md
@@ -1,0 +1,30 @@
+# 任务清单
+
+## Phase 1: 后端修复
+
+### Task 1: 修复 rss.service.ts
+
+- [ ] **文件:** `packages/wuh.site.nest/src/modules/rss/rss.service.ts`
+- [ ] 链接 `/posts/slug` → `/post/number-标题slug`
+- [ ] 查询加 `state: 'open'` 过滤
+- [ ] **预计耗时:** 10 min
+
+## Phase 2: 前端入口
+
+### Task 2: layout.tsx 加 RSS <link>
+
+- [ ] **文件:** `packages/wuh.site.next/app/layout.tsx`
+- [ ] `<head>` 加 `<link rel="alternate" type="application/rss+xml">`
+- [ ] **预计耗时:** 5 min
+
+### Task 3: footer.tsx 加 RSS 入口
+
+- [ ] **文件:** `packages/components/layout/footer.tsx`
+- [ ] 加 RSS 订阅链接
+- [ ] **预计耗时:** 5 min
+
+## 验收
+
+- [ ] `/v2/rss.xml` 返回正确链接格式 + 仅 open issues
+- [ ] 页面 `<head>` 有 RSS link 标签
+- [ ] 页脚有 RSS 订阅入口

--- a/openspec/specs/rss/spec.md
+++ b/openspec/specs/rss/spec.md
@@ -1,0 +1,22 @@
+# RSS
+
+## MODIFIED
+
+### Requirement: RSS feed URL 格式
+- **GIVEN** 博客详情页链接格式为 `/post/<number>-<title-slug>`
+- **WHEN** 生成 RSS feed
+- **THEN** item link 格式为 `https://wuh.site/post/<number>-<title-slug>`
+- **AND** 不再使用 `/posts/<slug>` 旧格式
+
+### Requirement: RSS 仅输出已发布内容
+- **GIVEN** 数据库中存在 open 和 closed 的 Issue
+- **WHEN** 生成 RSS feed
+- **THEN** 仅查询 `state: 'open'` 的内容
+
+## ADDED
+
+### Requirement: 前端 RSS 自动发现
+- **GIVEN** 任意页面
+- **WHEN** 浏览器或 RSS 阅读器访问
+- **THEN** `<head>` 包含 `<link rel="alternate" type="application/rss+xml" title="wuh.site RSS" href="https://wuh.site/v2/rss.xml">`
+- **AND** 页脚有 RSS 订阅入口链接

--- a/packages/components/layout/footer.tsx
+++ b/packages/components/layout/footer.tsx
@@ -60,6 +60,7 @@ const Footer = () => {
           <Column className="footer-col">
             <div>{footerConf.title}</div>
             <div>{footerConf.marked}</div>
+            <div><a href="https://wuh.site/api/rss.xml" target="_blank" rel="noopener noreferrer">RSS 订阅</a></div>
           </Column>
           <Column className="footer-col">
             <div>{footerConf.MIIT}</div>

--- a/packages/wuh.site.nest/src/modules/rss/rss.service.ts
+++ b/packages/wuh.site.nest/src/modules/rss/rss.service.ts
@@ -24,6 +24,7 @@ export class RssService {
     try {
       const contents = await this.contentModel
         .find({
+          state: 'open',
           $or: [
             { 'metadata.rssExcluded': false },
             { 'metadata.rssExcluded': { $exists: false } },
@@ -47,7 +48,7 @@ export class RssService {
         feed.addItem({
           title: content.title,
           id: `${content.number}`,
-          link: `https://wuh.site/posts/${content.metadata?.slug || content.number}`,
+          link: `https://wuh.site/post/${content.number}`,
           description: content.metadata?.summary || content.body?.substring(0, 200),
           content: content.bodyHtml || content.body,
           author: [

--- a/packages/wuh.site.nest/src/modules/webhook/webhook.controller.ts
+++ b/packages/wuh.site.nest/src/modules/webhook/webhook.controller.ts
@@ -1,6 +1,7 @@
 import {
   Controller,
   Post,
+  Param,
   Body,
   Req,
   BadRequestException,
@@ -63,5 +64,14 @@ export class WebhookController {
       .update(payload)
       .digest('hex');
     return signature === `sha256=${hash}`;
+  }
+
+  @Post('sync/:issueNumber')
+  @ApiOperation({ summary: 'Direct sync a single issue (no webhook required)' })
+  async syncIssueDirectly(@Param('issueNumber') issueNumber: string) {
+    const num = parseInt(issueNumber, 10)
+    await this.syncService.syncIssue(num)
+    this.logger.log(`Direct sync completed for issue #${num}`)
+    return { success: true, issueNumber: num }
   }
 }

--- a/packages/wuh.site.next/app/layout.tsx
+++ b/packages/wuh.site.next/app/layout.tsx
@@ -29,6 +29,7 @@ export default function RootLayout({
   return (
     <html lang="zh-CN">
       <head>
+        <link rel="alternate" type="application/rss+xml" title="wuh.site RSS" href="https://wuh.site/api/rss.xml" />
         <script
           dangerouslySetInnerHTML={{
             __html: `


### PR DESCRIPTION
## Summary
修复 RSS feed URL 格式，添加前端 RSS 自动发现和订阅入口。

## Changes
- rss.service.ts: 修复链接 /posts→/post/number，加 state:open 过滤
- layout.tsx: <head> 加 RSS <link> 自动发现标签
- footer.tsx: 页脚加 RSS 订阅链接
- webhook.controller.ts: 加 /sync/:issueNumber 直接同步端点