### PR TITLE
feat(message): Toast 主题色跟随 CSS 变量

### DIFF
--- a/openspec/changes/20260701_P_message_theme_redesign/.openspec.yaml
+++ b/openspec/changes/20260701_P_message_theme_redesign/.openspec.yaml
@@ -1,0 +1,5 @@
+project: x.wuh.site
+change: message-theme-redesign
+date: 2026-07-01
+type: P
+status: proposed

--- a/openspec/changes/20260701_P_message_theme_redesign/proposal.md
+++ b/openspec/changes/20260701_P_message_theme_redesign/proposal.md
@@ -1,0 +1,16 @@
+# Toast 提示框主题重新设计
+
+## 背景
+
+当前 Message/Toast 组件使用硬编码的 `--background-100` 和 `--normal-300` 颜色，未跟随主题（酒红/素雅）和亮暗模式变动。暗黑模式下使用 `color-mix` 混色做适配，但视觉上不够协调。
+
+## 目标
+
+- Toast 背景色跟随 `--background-color` 和 `--text-color` 主题令牌
+- 各类型（success/warning/error/info/loading）的颜色更鲜明
+- 暗黑模式下文字和背景对比度更清晰
+- 边框颜色使用 `color-mix` 与主题令牌混合
+
+## 影响范围
+
+- `packages/components/message/styles/index.tsx` — 主题修改

--- a/openspec/changes/20260701_P_message_theme_redesign/specs/message/spec.md
+++ b/openspec/changes/20260701_P_message_theme_redesign/specs/message/spec.md
@@ -1,0 +1,11 @@
+# Message Theme
+
+## MODIFIED
+
+### Requirement: Toast 主题色跟随
+- **GIVEN** 用户切换酒红/素雅主题 或 亮暗模式
+- **WHEN** Toast 提示框弹出
+- **THEN** 背景色使用 `var(--background-color)` 主题令牌
+- **AND** 文字色使用 `var(--text-color)` 主题令牌
+- **AND** 边框色使用 `color-mix(in srgb, var(--text-color) 12%, transparent)`
+- **AND** 暗黑模式下阴影更深，对比度更高

--- a/openspec/changes/20260701_P_message_theme_redesign/tasks.md
+++ b/openspec/changes/20260701_P_message_theme_redesign/tasks.md
@@ -1,0 +1,12 @@
+# 任务清单
+
+## Phase 1: Toast 主题重设计
+
+### Task 1: 重写 Message 样式
+
+- [ ] **文件:** `packages/components/message/styles/index.tsx`
+- [ ] MessageItem 背景用 `--background-color`，文字用 `--text-color`
+- [ ] MessageIcon 类型颜色保持不变（success/warning/error/loading/info）
+- [ ] 暗黑模式下通过 `@media (prefers-color-scheme: dark)` 放大 box-shadow
+- [ ] **预计耗时:** 15 min
+- [ ] **验证:** 切换酒红/素雅 + 亮/暗，Toast 颜色跟随

--- a/packages/components/message/styles/index.tsx
+++ b/packages/components/message/styles/index.tsx
@@ -91,13 +91,13 @@ export const MessageItem = styled.div<{ $type: MessageType; $leaving: boolean }>
   gap: 10px;
   padding: 10px 14px;
   border-radius: 10px;
-  background: var(--background-100);
-  border: 1px solid var(--normal-300);
-  color: var(--text-primary);
+  background: var(--background-color);
+  border: 1px solid color-mix(in srgb, var(--text-color) 12%, transparent);
+  color: var(--text-color);
   font-size: 14px;
   line-height: 1.5;
   max-width: min(560px, calc(100vw - 32px));
-  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
   animation: ${(props) => (props.$leaving ? fadeOut : fadeIn)} 0.22s ease;
 
   @media (prefers-reduced-motion: reduce) {
@@ -105,8 +105,7 @@ export const MessageItem = styled.div<{ $type: MessageType; $leaving: boolean }>
   }
 
   @media (prefers-color-scheme: dark) {
-    background: color-mix(in oklab, var(--background-200) 70%, var(--normal-900) 30%);
-    border-color: var(--normal-600);
+    border-color: color-mix(in srgb, var(--text-color) 18%, transparent);
     box-shadow: 0 14px 32px rgba(0, 0, 0, 0.35);
   }
 `
@@ -189,8 +188,8 @@ export const MessageCloseButton = styled.button`
   }
 
   &:hover {
-    color: var(--text-primary);
-    background: color-mix(in srgb, var(--normal-200) 70%, transparent);
+    color: var(--text-color);
+    background: color-mix(in srgb, var(--text-color) 8%, transparent);
   }
 
   &:focus-visible {
@@ -199,11 +198,9 @@ export const MessageCloseButton = styled.button`
   }
 
   @media (prefers-color-scheme: dark) {
-    color: var(--normal-400);
-
     &:hover {
-      color: var(--text-primary);
-      background: color-mix(in srgb, var(--normal-700) 70%, transparent);
+      color: var(--text-color);
+      background: color-mix(in srgb, var(--text-color) 16%, transparent);
     }
   }
 `


### PR DESCRIPTION
## Summary
Toast/Message 提示框背景、文字、边框颜色跟随主题 CSS 变量变动

## Changes
- MessageItem 背景改用 var(--background-color)
- MessageItem 文字改用 var(--text-color)
- 边框色用 color-mix(in srgb, var(--text-color) 12%, transparent)
- 暗黑模式边框和阴影优化
- 关闭按钮 hover 跟随主题色