### PR TITLE
feat: 时间展示格式优化 + 评论数改为浏览量

### DIFF
--- a/openspec/changes/20260701_P_date_format_view_count/.openspec.yaml
+++ b/openspec/changes/20260701_P_date_format_view_count/.openspec.yaml
@@ -1,0 +1,6 @@
+project: x.wuh.site
+change: date-format-view-count
+date: 2026-07-01
+type: P
+status: proposed
+issue: https://github.com/stack-wuh/x.wuh.site/issues/168

--- a/openspec/changes/20260701_P_date_format_view_count/design.md
+++ b/openspec/changes/20260701_P_date_format_view_count/design.md
@@ -1,0 +1,41 @@
+# 设计文档
+
+## 智能日期格式化
+
+```ts
+function formatRelativeTime(dateStr: string): string {
+  const d = new Date(dateStr)
+  const now = Date.now()
+  const diff = now - d.getTime()
+  const hours = diff / 3600000
+  const days = diff / 86400000
+
+  if (hours < 24) return `${Math.floor(hours)}小时前发布`
+  if (days < 7) return `${Math.floor(days)}天前发布`
+  if (days < 30) return `${d.getMonth() + 1}月${d.getDate()}日`
+  return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日`
+}
+```
+
+## 首页/列表页日期
+
+```ts
+function formatShortDate(dateStr: string): string {
+  const d = new Date(dateStr)
+  return `${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+```
+
+## PostListItem 字段变更
+
+```
+comments: number  →  views: number
+```
+
+前端映射时 `views: 0`（占位），后续可接入真实计数。
+
+## 影响分析
+
+- **新增依赖:** 无
+- **破坏性变更:** PostListItem 字段 rename，需确认无其他消费者
+- **向后兼容:** 不影响后端 API

--- a/openspec/changes/20260701_P_date_format_view_count/proposal.md
+++ b/openspec/changes/20260701_P_date_format_view_count/proposal.md
@@ -1,0 +1,28 @@
+# 日期格式优化 + 浏览数替换评论数
+
+## 背景
+
+当前首页/博客列表展示 "月份缩写 日" 格式 + 评论数，详情页展示固定 "发布于 2025 Jan 1, N条评论" 格式。体验不友好。
+
+## 目标
+
+- 首页/博客列表：日期改为 MM-dd 格式，评论数改为浏览量（占位）
+- 博客详情页：智能日期格式 + 浏览量
+  - 1天内 → "X小时前发布"
+  - 1周内 → "X天前发布"
+  - 1月内 → "MM月dd日发布"
+  - 超1月 → "YYYY年MM月dd日"
+- `PostListItem.comments` 改为 `PostListItem.views`，前端各处同步
+
+## 非目标（明确不做）
+
+- 不实现真实的浏览量计数
+- 不修改后端 API（views 字段暂用 0 占位）
+
+## 影响范围
+
+- `packages/shared-contracts/src/index.ts` — PostListItem.comments → views
+- `packages/wuh.site.next/app/HomeView.tsx` — 日期 MM-dd + views
+- `packages/wuh.site.next/app/blog/BlogListView.tsx` — 日期 MM-dd + views
+- `packages/wuh.site.next/app/blog/page.tsx` — mapContentToPost 映射 views
+- `packages/wuh.site.next/app/post/components/PostHeader.tsx` — 智能日期 + views

--- a/openspec/changes/20260701_P_date_format_view_count/specs/blog-display/spec.md
+++ b/openspec/changes/20260701_P_date_format_view_count/specs/blog-display/spec.md
@@ -1,0 +1,18 @@
+# Blog Display
+
+## MODIFIED
+
+### Requirement: 首页/列表页时间格式
+- **GIVEN** 首页或博客列表页展示文章列表
+- **WHEN** 页面渲染
+- **THEN** 日期格式为 MM-dd
+- **AND** 展示浏览量代替评论数
+
+### Requirement: 详情页时间格式
+- **GIVEN** 博客详情页
+- **WHEN** 页面渲染
+- **THEN** 发布时间在 1 天内显示 "X小时前发布"
+- **AND** 1 周内显示 "X天前发布"
+- **AND** 1 月内显示 "MM月dd日"
+- **AND** 超过 1 月显示 "YYYY年MM月dd日"
+- **AND** 展示浏览量代替评论数

--- a/openspec/changes/20260701_P_date_format_view_count/tasks.md
+++ b/openspec/changes/20260701_P_date_format_view_count/tasks.md
@@ -1,0 +1,44 @@
+# 任务清单
+
+## Phase 1: 类型和工具函数
+
+### Task 1: PostListItem.comments → views
+
+- [ ] **文件:** `packages/shared-contracts/src/index.ts`
+- [ ] `PostListItem.comments` → `PostListItem.views`
+- [ ] `blog/page.tsx` 映射 `views: 0`
+- [ ] **预计耗时:** 5 min
+
+### Task 2: 日期格式化工具函数
+
+- [ ] **文件:** `packages/wuh.site.next/app/lib/date.ts`（新建）
+- [ ] 实现 `formatShortDate(dateStr)` — MM-dd
+- [ ] 实现 `formatRelativeTime(dateStr)` — 相对时间
+- [ ] **预计耗时:** 10 min
+
+## Phase 2: 前端页面更新
+
+### Task 3: 首页和博客列表
+
+- [ ] **文件:** `packages/wuh.site.next/app/HomeView.tsx`
+- [ ] 日期改 `formatShortDate`
+- [ ] `post.comments` → `post.views`
+- [ ] **文件:** `packages/wuh.site.next/app/blog/BlogListView.tsx`
+- [ ] 日期改 `formatShortDate`
+- [ ] `post.comments` → `post.views`
+- [ ] **预计耗时:** 10 min
+
+### Task 4: 详情页 PostHeader
+
+- [ ] **文件:** `packages/wuh.site.next/app/post/components/PostHeader.tsx`
+- [ ] 日期改 `formatRelativeTime`
+- [ ] `issue.comments`条评论 → 浏览量标识
+- [ ] **预计耗时:** 5 min
+
+## 验收
+
+- [ ] 首页日期 MM-dd，展示"浏览量"字样的数值
+- [ ] 博客列表同上
+- [ ] 详情页 1天内文章显示 "X小时前发布"
+- [ ] 详情页 1周内文章显示 "X天前发布"
+- [ ] `npx tsc --noEmit` 零错误

--- a/openspec/changes/20260701_P_message_theme_redesign/.openspec.yaml
+++ b/openspec/changes/20260701_P_message_theme_redesign/.openspec.yaml
@@ -1,0 +1,5 @@
+project: x.wuh.site
+change: message-theme-redesign
+date: 2026-07-01
+type: P
+status: proposed

--- a/openspec/changes/20260701_P_message_theme_redesign/proposal.md
+++ b/openspec/changes/20260701_P_message_theme_redesign/proposal.md
@@ -1,0 +1,16 @@
+# Toast 提示框主题重新设计
+
+## 背景
+
+当前 Message/Toast 组件使用硬编码的 `--background-100` 和 `--normal-300` 颜色，未跟随主题（酒红/素雅）和亮暗模式变动。暗黑模式下使用 `color-mix` 混色做适配，但视觉上不够协调。
+
+## 目标
+
+- Toast 背景色跟随 `--background-color` 和 `--text-color` 主题令牌
+- 各类型（success/warning/error/info/loading）的颜色更鲜明
+- 暗黑模式下文字和背景对比度更清晰
+- 边框颜色使用 `color-mix` 与主题令牌混合
+
+## 影响范围
+
+- `packages/components/message/styles/index.tsx` — 主题修改

--- a/openspec/changes/20260701_P_message_theme_redesign/specs/message/spec.md
+++ b/openspec/changes/20260701_P_message_theme_redesign/specs/message/spec.md
@@ -1,0 +1,11 @@
+# Message Theme
+
+## MODIFIED
+
+### Requirement: Toast 主题色跟随
+- **GIVEN** 用户切换酒红/素雅主题 或 亮暗模式
+- **WHEN** Toast 提示框弹出
+- **THEN** 背景色使用 `var(--background-color)` 主题令牌
+- **AND** 文字色使用 `var(--text-color)` 主题令牌
+- **AND** 边框色使用 `color-mix(in srgb, var(--text-color) 12%, transparent)`
+- **AND** 暗黑模式下阴影更深，对比度更高

--- a/openspec/changes/20260701_P_message_theme_redesign/tasks.md
+++ b/openspec/changes/20260701_P_message_theme_redesign/tasks.md
@@ -1,0 +1,12 @@
+# 任务清单
+
+## Phase 1: Toast 主题重设计
+
+### Task 1: 重写 Message 样式
+
+- [ ] **文件:** `packages/components/message/styles/index.tsx`
+- [ ] MessageItem 背景用 `--background-color`，文字用 `--text-color`
+- [ ] MessageIcon 类型颜色保持不变（success/warning/error/loading/info）
+- [ ] 暗黑模式下通过 `@media (prefers-color-scheme: dark)` 放大 box-shadow
+- [ ] **预计耗时:** 15 min
+- [ ] **验证:** 切换酒红/素雅 + 亮/暗，Toast 颜色跟随

--- a/packages/components/message/styles/index.tsx
+++ b/packages/components/message/styles/index.tsx
@@ -91,13 +91,13 @@ export const MessageItem = styled.div<{ $type: MessageType; $leaving: boolean }>
   gap: 10px;
   padding: 10px 14px;
   border-radius: 10px;
-  background: var(--background-100);
-  border: 1px solid var(--normal-300);
-  color: var(--text-primary);
+  background: var(--background-color);
+  border: 1px solid color-mix(in srgb, var(--text-color) 12%, transparent);
+  color: var(--text-color);
   font-size: 14px;
   line-height: 1.5;
   max-width: min(560px, calc(100vw - 32px));
-  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
   animation: ${(props) => (props.$leaving ? fadeOut : fadeIn)} 0.22s ease;
 
   @media (prefers-reduced-motion: reduce) {
@@ -105,8 +105,7 @@ export const MessageItem = styled.div<{ $type: MessageType; $leaving: boolean }>
   }
 
   @media (prefers-color-scheme: dark) {
-    background: color-mix(in oklab, var(--background-200) 70%, var(--normal-900) 30%);
-    border-color: var(--normal-600);
+    border-color: color-mix(in srgb, var(--text-color) 18%, transparent);
     box-shadow: 0 14px 32px rgba(0, 0, 0, 0.35);
   }
 `
@@ -189,8 +188,8 @@ export const MessageCloseButton = styled.button`
   }
 
   &:hover {
-    color: var(--text-primary);
-    background: color-mix(in srgb, var(--normal-200) 70%, transparent);
+    color: var(--text-color);
+    background: color-mix(in srgb, var(--text-color) 8%, transparent);
   }
 
   &:focus-visible {
@@ -199,11 +198,9 @@ export const MessageCloseButton = styled.button`
   }
 
   @media (prefers-color-scheme: dark) {
-    color: var(--normal-400);
-
     &:hover {
-      color: var(--text-primary);
-      background: color-mix(in srgb, var(--normal-700) 70%, transparent);
+      color: var(--text-color);
+      background: color-mix(in srgb, var(--text-color) 16%, transparent);
     }
   }
 `


### PR DESCRIPTION
## Summary

优化博客列表/首页和详情页的日期展示格式，将评论数替换为浏览量占位。

## Changes

- PostListItem.comments → views
- 首页/博客列表: 日期 MM-dd + 浏览量
- 博客详情页: 智能相对时间 (X小时前/X天前/X月X日/YYYY年X月X日) + 浏览量
- 新增 date.ts 工具函数

Closes #168