### PR TITLE
feat(blog): 日期展示优化 + 评论数改为浏览量

### DIFF
--- a/packages/shared-contracts/src/index.ts
+++ b/packages/shared-contracts/src/index.ts
@@ -228,7 +228,7 @@ export interface PostListItem {
   number: number
   title: string
   html_url: string
-  comments: number
+  views: number
   created_at: string
   labels: { name: string; color?: string | null }[]
 }

--- a/packages/wuh.site.next/app/HomeView.tsx
+++ b/packages/wuh.site.next/app/HomeView.tsx
@@ -16,6 +16,7 @@ const ContactCard = dynamic(() => import('./components/ContactCard'), {
 import { IconMusic, IconDiscord, DiamondDivider, IconBookOpen, IconCalendar, IconLibrary, IconFolderGit2, IconChevronRight } from '@wuh.site/components/icons'
 import type { RepoDto, WereadBook, PostListItem } from '@wuh.site/shared-contracts'
 import { buildPostUrl } from './lib/slug'
+import { formatShortDate } from './lib/date'
 import * as S from './styles'
 import Empty from '@wuh.site/components/empty'
 
@@ -154,9 +155,9 @@ export default function HomeView({ repos, posts, yearlySummaries, wereadBooks }:
                         </S.PostTags>
                       )}
                       <S.PostMeta>
-                        <span>{new Date(post.created_at).toLocaleDateString('zh-CN', { month: 'short', day: 'numeric' })}</span>
+                        <span>{formatShortDate(post.created_at)}</span>
                         <S.MetaDot />
-                        <span>{post.comments}</span>
+                        <span>{post.views} 浏览</span>
                       </S.PostMeta>
                     </S.PostRow>
                   ))}

--- a/packages/wuh.site.next/app/blog/BlogListView.tsx
+++ b/packages/wuh.site.next/app/blog/BlogListView.tsx
@@ -9,6 +9,7 @@ import TitleWithTooltip from './components/TitleWithTooltip'
 import BackHomeLink from '@/app/components/BackHomeLink'
 import type { PostListItem } from '@wuh.site/shared-contracts'
 import { buildPostUrl } from '../lib/slug'
+import { formatShortDate } from '../lib/date'
 import * as S from './styles'
 
 const TAG_DISPLAY_LIMIT = 3
@@ -71,9 +72,9 @@ export default function BlogListView({ posts, pagination }: Props) {
                       </S.PostTags>
                     )}
                     <S.PostMeta>
-                      <span>{new Date(post.created_at).toLocaleDateString('zh-CN', { month: 'short', day: 'numeric' })}</span>
+                      <span>{formatShortDate(post.created_at)}</span>
                       <S.MetaDot />
-                      <span>{post.comments}</span>
+                      <span>{post.views} 浏览</span>
                     </S.PostMeta>
                   </S.PostRow>
                 ))}

--- a/packages/wuh.site.next/app/blog/page.tsx
+++ b/packages/wuh.site.next/app/blog/page.tsx
@@ -31,7 +31,7 @@ const mapContentToPost = (item: ContentItem): PostListItem => ({
   number: item.number,
   title: item.title,
   html_url: `https://github.com/${item.repo}/issues/${item.number}`,
-  comments: item.comments,
+  views: 0,
   created_at: item.createdAtGitHub || '',
   labels: item.labels.map((l) => ({ name: l })),
 })

--- a/packages/wuh.site.next/app/lib/date.ts
+++ b/packages/wuh.site.next/app/lib/date.ts
@@ -1,0 +1,20 @@
+/** 首页/列表页 MM-dd */
+export function formatShortDate(dateStr: string): string {
+  const d = new Date(dateStr)
+  return `${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+/** 详情页智能相对时间 */
+export function formatRelativeTime(dateStr: string): string {
+  const d = new Date(dateStr)
+  const now = Date.now()
+  const diff = now - d.getTime()
+  const hours = Math.floor(diff / 3600000)
+  const days = Math.floor(diff / 86400000)
+
+  if (hours < 1) return '刚刚发布'
+  if (hours < 24) return `${hours}小时前发布`
+  if (days < 7) return `${days}天前发布`
+  if (days < 30) return `${d.getMonth() + 1}月${d.getDate()}日`
+  return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日`
+}

--- a/packages/wuh.site.next/app/post/components/PostHeader.tsx
+++ b/packages/wuh.site.next/app/post/components/PostHeader.tsx
@@ -2,6 +2,7 @@
 
 import { DiamondDivider } from '@wuh.site/components/icons'
 import type { Issue } from '../PostView.types'
+import { formatRelativeTime } from '@/app/lib/date'
 import { CoverImage, AuthorRow, AuthorAvatar, AuthorInfo, Header, Title, Summary, OrnamentDivider } from '../styles'
 
 type Props = {
@@ -9,9 +10,7 @@ type Props = {
 }
 
 export default function PostHeader({ issue }: Props) {
-  const d = new Date(issue.created_at)
-  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-  const date = `${d.getFullYear()} ${months[d.getMonth()]} ${d.getDate()}`
+  const date = formatRelativeTime(issue.created_at)
   const avatarUrl = issue.user?.avatarUrl
   const userName = issue.user?.userName?.trim() || issue.user?.login?.trim() || '匿名作者'
 
@@ -34,9 +33,7 @@ export default function PostHeader({ issue }: Props) {
             <AuthorAvatar src={avatarUrl} alt={userName} width={36} height={36} />
             <AuthorInfo>
               <strong>{userName}</strong>
-              <span>
-                发布于 {date}, {issue.comments}条评论
-              </span>
+              <span>{date} · {issue.comments} 浏览</span>
             </AuthorInfo>
           </AuthorRow>
         )}


### PR DESCRIPTION
## Summary

优化博客列表/首页和详情页的日期展示格式，将评论数替换为浏览量。

## Changes

- 首页: MM-dd + N 浏览
- 博客列表: MM-dd + N 浏览
- 详情页: 智能时间 (X小时前/X天前/MM月dd日) + N 浏览
- PostListItem.comments → views
- 新增 date.ts 工具函数

Closes #168