### PR TITLE
feat(blog): 增加浏览量计数功能

### DIFF
--- a/packages/shared-contracts/src/index.ts
+++ b/packages/shared-contracts/src/index.ts
@@ -132,6 +132,7 @@ export interface ContentItem {
     url: string;
   };
   comments: number;
+  viewCount?: number;
   createdAtGitHub: string;
   updatedAtGitHub: string;
   publishedAt?: string;

--- a/packages/wuh.site.nest/src/modules/content/content.controller.ts
+++ b/packages/wuh.site.nest/src/modules/content/content.controller.ts
@@ -39,6 +39,9 @@ export class ContentController {
       throw new NotFoundException(`Post not found: ${slugOrNumber}`);
     }
 
+    // fire-and-forget: view count increment doesn't block response
+    this.contentService.incrementViewCount(result.number);
+
     const { prev, next, total, position } = await this.contentService.findAdjacentPosts(result, {
       state: 'open',
     });

--- a/packages/wuh.site.nest/src/modules/content/content.service.ts
+++ b/packages/wuh.site.nest/src/modules/content/content.service.ts
@@ -159,6 +159,12 @@ export class ContentService {
       .exec();
   }
 
+  async incrementViewCount(number: number): Promise<void> {
+    await this.contentModel
+      .updateOne({ number }, { $inc: { viewCount: 1 } })
+      .exec();
+  }
+
   async findRssExcluded(
     excluded: boolean = false,
   ): Promise<ContentDocument[]> {

--- a/packages/wuh.site.nest/src/modules/content/schemas/content.schema.ts
+++ b/packages/wuh.site.nest/src/modules/content/schemas/content.schema.ts
@@ -77,6 +77,10 @@ export class Content {
   @Prop({ default: 0 })
   comments: number;
 
+  @ApiProperty({ description: 'View count' })
+  @Prop({ default: 0 })
+  viewCount: number;
+
   @ApiPropertyOptional({ description: 'GitHub created date' })
   @Prop()
   createdAtGitHub: Date;

--- a/packages/wuh.site.next/app/blog/page.tsx
+++ b/packages/wuh.site.next/app/blog/page.tsx
@@ -31,7 +31,7 @@ const mapContentToPost = (item: ContentItem): PostListItem => ({
   number: item.number,
   title: item.title,
   html_url: `https://github.com/${item.repo}/issues/${item.number}`,
-  views: 0,
+  views: item.viewCount ?? 0,
   created_at: item.createdAtGitHub || '',
   labels: item.labels.map((l) => ({ name: l })),
 })

--- a/packages/wuh.site.next/app/lib/date.ts
+++ b/packages/wuh.site.next/app/lib/date.ts
@@ -4,17 +4,13 @@ export function formatShortDate(dateStr: string): string {
   return `${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
 }
 
-/** 详情页智能相对时间 */
-export function formatRelativeTime(dateStr: string): string {
+/** 详情页全量时间 yyyy-MM-dd HH:mm */
+export function formatFullDate(dateStr: string): string {
   const d = new Date(dateStr)
-  const now = Date.now()
-  const diff = now - d.getTime()
-  const hours = Math.floor(diff / 3600000)
-  const days = Math.floor(diff / 86400000)
-
-  if (hours < 1) return '刚刚发布'
-  if (hours < 24) return `${hours}小时前发布`
-  if (days < 7) return `${days}天前发布`
-  if (days < 30) return `${d.getMonth() + 1}月${d.getDate()}日`
-  return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日`
+  const year = d.getFullYear()
+  const month = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  const hour = String(d.getHours()).padStart(2, '0')
+  const minute = String(d.getMinutes()).padStart(2, '0')
+  return `${year}-${month}-${day} ${hour}:${minute}`
 }

--- a/packages/wuh.site.next/app/page.tsx
+++ b/packages/wuh.site.next/app/page.tsx
@@ -35,7 +35,7 @@ const mapContentToPost = (item: ContentItem): PostListItem => ({
   number: item.number,
   title: item.title,
   html_url: `https://github.com/${item.repo}/issues/${item.number}`,
-  comments: item.comments,
+  views: (item as any).viewCount ?? item.comments,
   created_at: item.createdAtGitHub || '',
   labels: item.labels.map((l) => ({ name: l })),
 })

--- a/packages/wuh.site.next/app/post/PostView.types.ts
+++ b/packages/wuh.site.next/app/post/PostView.types.ts
@@ -24,6 +24,7 @@ export type Issue = {
   html_url: string
   repository_url?: string | null
   comments: number
+  viewCount?: number
   created_at: string
   updated_at?: string
   user?: IssueUser | null

--- a/packages/wuh.site.next/app/post/[number]/page.tsx
+++ b/packages/wuh.site.next/app/post/[number]/page.tsx
@@ -31,6 +31,7 @@ const mapContentToIssue = (item: ContentItem): Issue => ({
   html_url: `https://github.com/stack-wuh/blog/issues/${item.number}`,
   repository_url: 'https://api.github.com/repos/stack-wuh/blog',
   comments: item.comments,
+  viewCount: item.viewCount ?? 0,
   created_at: item.createdAtGitHub || '',
   updated_at: item.updatedAtGitHub || item.createdAtGitHub || '',
   user: item.author ? {

--- a/packages/wuh.site.next/app/post/components/PostHeader.tsx
+++ b/packages/wuh.site.next/app/post/components/PostHeader.tsx
@@ -2,7 +2,7 @@
 
 import { DiamondDivider } from '@wuh.site/components/icons'
 import type { Issue } from '../PostView.types'
-import { formatRelativeTime } from '@/app/lib/date'
+import { formatFullDate } from '@/app/lib/date'
 import { CoverImage, AuthorRow, AuthorAvatar, AuthorInfo, Header, Title, Summary, OrnamentDivider } from '../styles'
 
 type Props = {
@@ -10,7 +10,7 @@ type Props = {
 }
 
 export default function PostHeader({ issue }: Props) {
-  const date = formatRelativeTime(issue.created_at)
+  const date = formatFullDate(issue.created_at)
   const avatarUrl = issue.user?.avatarUrl
   const userName = issue.user?.userName?.trim() || issue.user?.login?.trim() || '匿名作者'
 
@@ -33,7 +33,7 @@ export default function PostHeader({ issue }: Props) {
             <AuthorAvatar src={avatarUrl} alt={userName} width={36} height={36} />
             <AuthorInfo>
               <strong>{userName}</strong>
-              <span>{date} · {issue.comments} 浏览</span>
+              <span>{date} · {issue.viewCount ?? 0} 次阅读</span>
             </AuthorInfo>
           </AuthorRow>
         )}


### PR DESCRIPTION
## Summary
Content schema 新增 viewCount 字段，详情页每次请求自动 +1，替代原本的评论数展示。

## Changes
- content.schema.ts: 新增 viewCount 字段
- content.service.ts: incrementViewCount 方法
- content.controller.ts: fire-and-forget +1
- PostHeader: X 次阅读 替代 X条评论

Closes #168