### PR TITLE
feat: 博客详情页底部工具栏布局优化

### DIFF
--- a/packages/wuh.site.next/app/post/PostView.tsx
+++ b/packages/wuh.site.next/app/post/PostView.tsx
@@ -237,6 +237,8 @@ export default function PostView({ issue, prevIssue, nextIssue, total, position 
             />
           </RedundantInfoCard>
 
+          <FloatingActions />
+
           <ShareInfoCard variant='outlined' elevation={0} fullWidth padding='md'>
             <ShareCardInner>
               <SharedLinkGroup items={shareItems} label='' />
@@ -257,8 +259,6 @@ export default function PostView({ issue, prevIssue, nextIssue, total, position 
           </TocAside>
         )}
       </ContentGrid>
-
-      <FloatingActions />
     </Container>
   )
 }

--- a/packages/wuh.site.next/app/post/components/FloatingActions.tsx
+++ b/packages/wuh.site.next/app/post/components/FloatingActions.tsx
@@ -10,32 +10,32 @@ export default function FloatingActions() {
       <FloatingButton
         type='button'
         aria-label='返回首页'
-        title='返回首页'
         onClick={() => {
           window.location.href = '/'
         }}
       >
         <IconHome />
+        <span>返回首页</span>
       </FloatingButton>
       <FloatingButton
         type='button'
         aria-label='返回页头'
-        title='返回页头'
         onClick={() => {
           window.scrollTo({ top: 0, behavior: 'smooth' })
         }}
       >
         <IconArrowUp />
+        <span>回到顶部</span>
       </FloatingButton>
       <FloatingButton
         type='button'
         aria-label='点赞（开发中）'
-        title='点赞（开发中）'
         onClick={() => {
           message.info('点赞功能正在开发中')
         }}
       >
         <IconLike />
+        <span>点赞</span>
       </FloatingButton>
     </FloatingButtonGroup>
   )

--- a/packages/wuh.site.next/app/post/styles/post-floating.ts
+++ b/packages/wuh.site.next/app/post/styles/post-floating.ts
@@ -1,80 +1,46 @@
-import styled, { css } from '@wuh.site/components/styled'
+import styled from '@wuh.site/components/styled'
 
 export const FloatingButtonGroup = styled.div`
-  --float-button-width: 50px;
-  --float-divider: var(--normal-300);
-
-  position: fixed;
-  right: 0;
-  bottom: var(--space-xl);
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-  z-index: 20;
-  border: 1px solid var(--normal-300);
-  border-right: 0;
-  border-top-left-radius: 14px;
-  border-bottom-left-radius: 14px;
-  overflow: hidden;
+  margin-top: var(--space-sm);
+  padding: var(--space-md);
   background: var(--background-100);
-
-  & > * {
-    width: var(--float-button-width);
-  }
-
-  & > * + * {
-    border-top: 1px solid var(--float-divider);
-  }
+  border: 1px solid color-mix(in oklab, var(--primary-color) 12%, var(--normal-300) 88%);
+  border-radius: var(--radius-card);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  justify-content: center;
+  align-items: center;
 
   @media (max-width: 640px) {
-    --float-button-width: 50px;
+    flex-direction: column;
+    gap: var(--space-xs);
   }
 
   @media (prefers-color-scheme: dark) {
-    border-color: var(--normal-600);
-    border-right-color: transparent;
-    background: color-mix(in oklab, var(--background-200) 75%, var(--background-900) 25%);
-    --float-divider: var(--normal-600);
-
-    & > * + * {
-      border-top-color: var(--float-divider);
-    }
+    border-color: color-mix(in oklab, var(--normal-700) 60%, transparent);
   }
 `
 
-const floatingButtonBase = css`
-  border: none;
-  background: transparent;
-  color: var(--text-primary);
-  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.12);
-  min-width: 50px;
-  min-height: 40px;
+export const FloatingButton = styled.button`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
-  padding: 0 12px;
-  font-size: 13px;
+  gap: var(--space-xs);
+  padding: var(--space-xs) var(--space-md);
+  min-height: 40px;
+  background: var(--background-200);
+  border: 1px solid var(--normal-300);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
   cursor: pointer;
   transition:
-    border-color 0.22s ease,
-    background-color 0.22s ease,
-    color 0.22s ease,
-    box-shadow 0.22s ease,
-    transform 0.22s ease;
-  will-change: transform;
-
-  &:hover {
-    color: var(--primary-color);
-    background: var(--background-200);
-    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.16);
-    transform: translateX(-2px);
-  }
-
-  &:focus-visible {
-    outline: 2px solid color-mix(in srgb, var(--primary-color) 35%, transparent);
-    outline-offset: 2px;
-  }
+    background-color var(--transition-fast) ease,
+    border-color var(--transition-fast) ease,
+    color var(--transition-fast) ease,
+    transform var(--transition-fast) ease;
 
   svg {
     width: 16px;
@@ -86,17 +52,38 @@ const floatingButtonBase = css`
     stroke-linejoin: round;
   }
 
+  &:hover {
+    background: var(--background-300);
+    border-color: var(--primary-color);
+    color: var(--primary-color);
+    transform: translateY(-1px);
+  }
+
+  &:active {
+    transform: translateY(0);
+  }
+
+  &:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--primary-color) 35%, transparent);
+    outline-offset: 2px;
+  }
+
+  @media (max-width: 640px) {
+    width: 100%;
+    justify-content: center;
+  }
+
   @media (prefers-color-scheme: dark) {
-    background: transparent;
-    box-shadow: 0 12px 26px rgba(0, 0, 0, 0.35);
+    background: var(--normal-700);
+    border-color: var(--normal-500);
 
     &:hover {
-      background: color-mix(in oklab, var(--background-300) 70%, var(--background-900) 30%);
+      background: var(--normal-600);
+      border-color: var(--primary-color);
     }
   }
-`
 
-export const FloatingButton = styled.button`
-  ${floatingButtonBase}
-  padding: 0;
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
 `


### PR DESCRIPTION
## 变更内容

将博客详情页右下角浮动按钮组改为正文下方的横向底部工具栏

## 改动点

- 位置调整：从固定在右下角改为放在正文下方（版权信息卡之后、分享区之前）
- 样式升级：改为卡片式横向工具栏，按钮带图标和文字标签
- 布局优化：移除固定定位，改为内联文档流，与文章结尾卡片体系一致
- 响应式支持：桌面端横向排列，移动端自动堆叠

## 验证

- ✅ 页面预览验证通过
- ✅ Linter 检查通过
- ✅ 交互功能正常（返回首页、回到顶部、点赞提示）
- ✅ 响应式布局正常