### PR TITLE
fix: 分享按钮组 hover pulse 动画改用主题色

### DIFF
--- a/packages/components/shared-link-group/index.tsx
+++ b/packages/components/shared-link-group/index.tsx
@@ -29,9 +29,9 @@ const fadeIn = keyframes`
 `
 
 const pulse = keyframes`
-  0% { box-shadow: 0 0 0 0 rgba(0,0,0,0.08); }
-  50% { box-shadow: 0 0 0 8px rgba(0,0,0,0.04); }
-  100% { box-shadow: 0 0 0 0 rgba(0,0,0,0); }
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--primary-color) 25%, transparent); }
+  50% { box-shadow: 0 0 0 8px color-mix(in srgb, var(--primary-color) 12%, transparent); }
+  100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--primary-color) 25%, transparent); }
 `
 
 const iconBounce = keyframes`


### PR DESCRIPTION
将分享按钮组 hover 时的 pulse 动画从硬编码  黑色阴影改为  主题色，与 FloatingButton 保持一致。