### PR TITLE
feat(blog): 文章点赞功能

### DIFF
--- a/packages/shared-contracts/src/endpoints.ts
+++ b/packages/shared-contracts/src/endpoints.ts
@@ -13,6 +13,7 @@ export const contentService = defineService({
   getPosts:    { url: '/content/posts',       method: 'GET' },
   getPost:     { url: '/content/posts/:slug', method: 'GET' },
   getProjects: { url: '/content/projects',    method: 'GET' },
+  likePost:    { url: '/content/posts/:number/like', method: 'POST' },
 })
 
 export const reposService = defineService({

--- a/packages/wuh.site.nest/src/modules/content/content.controller.ts
+++ b/packages/wuh.site.nest/src/modules/content/content.controller.ts
@@ -1,7 +1,20 @@
-import { Controller, Get, Param, Query, NotFoundException } from '@nestjs/common';
+import { Controller, Get, Param, Query, NotFoundException, Post, Req } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiQuery, ApiResponse } from '@nestjs/swagger';
 import { ContentService } from './content.service';
 import { QueryContentDto } from './dto/content.dto';
+import { Request } from 'express';
+
+const likeIpMap = new Map<string, Set<number>>();
+
+function hasLiked(ip: string, number: number): boolean {
+  const set = likeIpMap.get(ip);
+  return set ? set.has(number) : false;
+}
+
+function markLiked(ip: string, number: number): void {
+  if (!likeIpMap.has(ip)) likeIpMap.set(ip, new Set());
+  likeIpMap.get(ip)!.add(number);
+}
 
 @ApiTags('Content')
 @Controller('content')
@@ -55,9 +68,22 @@ export class ContentController {
     };
   }
 
+  @Post('posts/:number/like')
+  @ApiOperation({ summary: 'Like a post' })
+  @ApiResponse({ status: 200, description: 'Like recorded' })
+  @ApiResponse({ status: 400, description: 'Already liked' })
+  async likePost(@Param('number') number: string, @Req() req: Request) {
+    const num = parseInt(number, 10);
+    const ip = req.ip || req.socket.remoteAddress || 'unknown';
+    if (hasLiked(ip, num)) {
+      return { liked: false, likeCount: 0, message: 'Already liked' };
+    }
+    markLiked(ip, num);
+    await this.contentService.incrementLikeCount(num);
+    return { liked: true, message: 'Liked' };
+  }
+
   @Get('projects')
-  @ApiOperation({ summary: 'Get paginated projects' })
-  @ApiQuery({ name: 'page', required: false, type: Number })
   @ApiQuery({ name: 'limit', required: false, type: Number })
   @ApiResponse({ status: 200, description: 'Paginated list of projects' })
   async getProjects(@Query() query: QueryContentDto) {

--- a/packages/wuh.site.nest/src/modules/content/content.service.ts
+++ b/packages/wuh.site.nest/src/modules/content/content.service.ts
@@ -165,6 +165,12 @@ export class ContentService {
       .exec();
   }
 
+  async incrementLikeCount(number: number): Promise<void> {
+    await this.contentModel
+      .updateOne({ number }, { $inc: { likeCount: 1 } })
+      .exec();
+  }
+
   async findRssExcluded(
     excluded: boolean = false,
   ): Promise<ContentDocument[]> {

--- a/packages/wuh.site.nest/src/modules/content/schemas/content.schema.ts
+++ b/packages/wuh.site.nest/src/modules/content/schemas/content.schema.ts
@@ -81,6 +81,10 @@ export class Content {
   @Prop({ default: 0 })
   viewCount: number;
 
+  @ApiProperty({ description: 'Like count' })
+  @Prop({ default: 0 })
+  likeCount: number;
+
   @ApiPropertyOptional({ description: 'GitHub created date' })
   @Prop()
   createdAtGitHub: Date;

--- a/packages/wuh.site.next/app/post/PostView.tsx
+++ b/packages/wuh.site.next/app/post/PostView.tsx
@@ -240,7 +240,7 @@ export default function PostView({ issue, prevIssue, nextIssue, total, position 
           <ShareInfoCard variant='outlined' elevation={0} fullWidth padding='md'>
             <ShareCardInner>
               <SharedLinkGroup items={shareItems} label='' />
-              <FloatingActions />
+              <FloatingActions issueNumber={issue.number} initialLikeCount={issue.likeCount ?? 0} />
             </ShareCardInner>
           </ShareInfoCard>
 

--- a/packages/wuh.site.next/app/post/PostView.types.ts
+++ b/packages/wuh.site.next/app/post/PostView.types.ts
@@ -25,6 +25,7 @@ export type Issue = {
   repository_url?: string | null
   comments: number
   viewCount?: number
+  likeCount?: number
   created_at: string
   updated_at?: string
   user?: IssueUser | null

--- a/packages/wuh.site.next/app/post/[number]/page.tsx
+++ b/packages/wuh.site.next/app/post/[number]/page.tsx
@@ -32,6 +32,7 @@ const mapContentToIssue = (item: ContentItem): Issue => ({
   repository_url: 'https://api.github.com/repos/stack-wuh/blog',
   comments: item.comments,
   viewCount: item.viewCount ?? 0,
+  likeCount: item.likeCount ?? 0,
   created_at: item.createdAtGitHub || '',
   updated_at: item.updatedAtGitHub || item.createdAtGitHub || '',
   user: item.author ? {

--- a/packages/wuh.site.next/app/post/components/FloatingActions.tsx
+++ b/packages/wuh.site.next/app/post/components/FloatingActions.tsx
@@ -1,10 +1,37 @@
 'use client'
 
+import { useState, useCallback } from 'react'
 import message from '@wuh.site/components/message'
 import { IconHome, IconArrowUp, IconThumbUp } from '@wuh.site/components/icons'
 import { FloatingButtonGroup, FloatingButton, LikeButton } from '../styles'
 
-export default function FloatingActions() {
+export default function FloatingActions({ issueNumber, initialLikeCount = 0 }: {
+  issueNumber: number
+  initialLikeCount?: number
+}) {
+  const [liked, setLiked] = useState(false)
+  const [likeCount, setLikeCount] = useState(initialLikeCount)
+  const [loading, setLoading] = useState(false)
+
+  const handleLike = useCallback(async () => {
+    if (liked || loading) return
+    setLoading(true)
+    try {
+      const res = await fetch(`/v2/content/posts/${issueNumber}/like`, { method: 'POST' })
+      const data = await res.json()
+      if (data.liked) {
+        setLiked(true)
+        setLikeCount((c) => c + 1)
+      } else {
+        message.info('你已经点过赞了')
+      }
+    } catch {
+      message.error('点赞失败，请稍后再试')
+    } finally {
+      setLoading(false)
+    }
+  }, [issueNumber, liked, loading])
+
   return (
     <FloatingButtonGroup>
       <FloatingButton
@@ -31,12 +58,12 @@ export default function FloatingActions() {
         type='button'
         aria-label='点赞'
         title='点赞'
-        onClick={() => {
-          message.info('点赞功能正在开发中')
-        }}
+        onClick={handleLike}
+        disabled={loading}
+        style={liked ? { opacity: 0.7, cursor: 'default' } : undefined}
       >
         <IconThumbUp />
-        <span>点赞</span>
+        <span>{likeCount > 0 ? `赞 ${likeCount}` : '点赞'}</span>
       </LikeButton>
     </FloatingButtonGroup>
   )


### PR DESCRIPTION
后端: Content schema 新增 likeCount, ContentService 新增 incrementLikeCount, Controller 新增 POST like 端点 + IP 去重. 前端: FloatingActions 对接真实 API, 显示点赞数和状态