### PR TITLE
feat: 优化 About 留言板体验

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,110 @@
+# x.wuh.site
+
+基于 Next.js 15 + React 19 + NestJS 10 + MongoDB 的个人博客 monorepo，使用 GitHub Issues 作为 CMS。
+
+## 仓库结构
+
+```
+packages/
+├── wuh.site.next      # 主站前端 (Next.js 15 App Router, port 3000)
+├── wuh.site.nest      # 后端 API (NestJS 10 + Mongoose 8, port 3200)
+├── components         # UI 组件库 @wuh.site/components
+├── hooks              # 共享 hooks (useTheme, useFetch, useDialog, etc.)
+├── config             # 类型/配置包
+├── shared-contracts   # 前后端共享 DTO 类型
+└── docs               # 文档预留
+codex/                 # Codex 工作流历史，可参考但不再使用
+```
+
+## 技术栈
+
+- **前端**: Next.js 15.1 (App Router), React 19.2, TypeScript 5, styled-components 6
+- **后端**: NestJS 10, Mongoose 8, Octokit (GitHub API), Pino (日志), Sentry
+- **数据库**: MongoDB (via Mongoose)
+- **包管理**: pnpm workspace, lockfile v9
+- **CI/CD**: GitHub Actions → Docker → SSH 部署
+- **环境要求**: Node.js >= 20, pnpm >= 9
+
+## 常用命令
+
+```bash
+# 前端
+pnpm dev:next        # Next.js 开发服务器 (port 3000)
+pnpm build:next      # 构建 Next.js
+pnpm start:next      # 生产启动 Next.js
+
+# 后端
+pnpm dev:nest        # NestJS 开发服务器 (port 3200, watch 模式)
+pnpm build:nest      # 构建 NestJS
+pnpm start:nest      # 生产启动 NestJS
+pnpm sync:init       # 从 GitHub Issues 全量同步数据到 MongoDB
+
+# 全局
+pnpm install         # 安装所有依赖
+pnpm exec tsc --noEmit  # TypeScript 类型检查
+```
+
+## 开发规范
+
+### 导入路径
+- 组件导入使用 `@wuh.site/components/<name>`（如 `@wuh.site/components/button`）
+- hooks 从 `packages/hooks` 导入
+- 共享类型从 `@wuh.site/shared-contracts` 导入
+- 前端内部路径使用 `@/*` 别名映射到项目根目录
+
+### 前端规范
+- **客户端组件**: 交互式组件必须添加 `'use client'` 指令
+- **SSR 安全**: 浏览器 API（`window`/`document`）需要 `typeof window !== 'undefined'` guard
+- **样式**: 使用 styled-components 瞬态 props（`$` 前缀，如 `$variant`），CSS 变量主题令牌
+- **主题**: `ThemeProvider` → `StyledComponentsRegistry` → `CssVariableStyles`（已在 app layout 中配置）
+- **路由**: `/`(首页), `/blog`(博客列表), `/post/[number]`(博客详情), `/about`, `/design/system-color`
+- **数据源**: GitHub API (repos, issues, markdown rendering)，使用 `fetch` + `revalidate` 做 ISR
+
+### 后端规范
+- **架构**: Module → Controller → Service → DTO/validation → Schema
+- **DTO 验证**: 使用 class-validator 装饰器
+- **日志**: 使用 Pino (`private logger = new Logger(ServiceName.name)`)
+- **错误处理**: 使用 NestJS 内置异常 (`BadRequestException`, `NotFoundException` 等)
+- **数据库**: 使用 Mongoose `lean()` 优化读取，Upsert 模式处理同步
+
+### Monorepo 约定
+- 保持包边界清晰，避免不必要的跨包耦合
+- 小步快跑，优先多次小 PR
+- 使用 conventional commits（commitlint 强制）
+
+## 组件库清单
+
+### 已实现组件
+`Alert`, `Button`, `Card`, `Dialog`, `Empty`, `Skeleton`, `Result`, `Flex/Row/Column`, `Image`, `ImagePreview`, `LinkGroup`, `SharedLinkGroup`, `Tag`, `Message`, `AudioPlayer` (含 Provider + Mini Player + Panel), `Layout` (footer/main)
+
+### 占位组件（使用前需实现）
+`Col`, `ConfigProvider`, `Divider`, `FloatButton`, `Modal`, `Row`, `Space`, `Spin`, `VideoPlayer`
+
+### Hooks
+- `useDialog` - Dialog 打开/关闭状态，提供 `bind: { open, onClose }`
+- `useImagePreview` - 图片预览索引/循环状态，提供 `bind: { open, currentIndex, onClose, onIndexChange }`
+- `useTokens` / `useTheme` - 从 ThemeProvider context 获取主题令牌
+- `useFetch` - 请求封装
+
+## 后端模块架构
+
+```
+src/modules/
+├── content/      # 内容管理 (博客/项目 CRUD)
+├── comment/      # 留言系统 (匿名评论 -> GitHub sync)
+├── sync/         # GitHub Issues 全量/增量同步
+├── webhook/      # GitHub Webhook 事件处理
+├── rss/          # RSS 2.0 订阅源
+├── user/         # 用户角色管理 (root/writer/reader)
+├── auth/         # GitHub OAuth + JWT
+├── admin/        # 管理接口
+├── repos/        # GitHub 仓库数据
+├── weread/       # 微信读书书架同步与展示
+└── api-v2/       # 新版统一 API
+```
+
+## 记忆存储
+
+错误/阻塞经验自动记录到: `~/.Codex/projects/-Users-wuhong-shadow-desktop-github-x-wuh-site/memory/`
+
+跨会话积累，避免重复踩坑。

--- a/openspec/INDEX.md
+++ b/openspec/INDEX.md
@@ -73,9 +73,9 @@
 - **需求:** Global exception filter, Swagger API documentation
 - **路径:** `openspec/specs/error-handling/spec.md`
 
-## guestbook-barrage — 留言弹幕弹窗
-- **关键词:** 留言, 弹幕, Dialog, 响应式, 输入限制
-- **需求:** 弹窗留言入口, 弹幕区域默认可见, 输入框字数限制, 桌面端左右并列展示, 移动端上下布局展示, 弹幕与列表视觉参考 B 站, 弹窗默认不展示列表
+## guestbook-barrage — 留言板群聊弹窗
+- **关键词:** 留言, 群聊, Dialog, About入口, 即时提交, 错误日志
+- **需求:** About 页面留言板入口, 群聊式留言弹窗, 输入框字数限制, 点击发送即提交, 缓存留言昵称, Next 留言代理, 匿名留言字段对齐, dev 与 build 输出目录隔离
 - **路径:** `openspec/specs/guestbook-barrage/spec.md`
 
 ## redesign-error-pages — 错误页面重设计

--- a/openspec/changes/archive/2026-07-05-P-about-guestbook-chat-ui/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-05-P-about-guestbook-chat-ui/.openspec.yaml
@@ -1,0 +1,6 @@
+project: x.wuh.site
+change: about-guestbook-chat-ui
+date: 2026-07-05
+type: P
+status: applied
+issue: local

--- a/openspec/changes/archive/2026-07-05-P-about-guestbook-chat-ui/design.md
+++ b/openspec/changes/archive/2026-07-05-P-about-guestbook-chat-ui/design.md
@@ -1,0 +1,62 @@
+# 设计：About 页面留言板群聊化改造
+
+## 1. 入口 UI
+
+About 页面保留窄栏内容结构，留言板作为独立 section 出现在“足迹”之后：
+- 由页面提供 `SectionHeader + SectionLabel`，与现有模块保持一致。
+- 入口卡片使用 8px 圆角、细边框、左侧 accent 线，降低工具按钮感。
+- 左侧使用叠放昵称头像，暗示群聊语境。
+- 主体文案说明“给我留一句话”，右侧提供轻量 `进入` CTA。
+
+## 2. 弹窗交互
+
+弹窗主区从弹幕轨道改为聊天消息流：
+- 示例消息使用左侧气泡。
+- 用户提交的新消息使用右侧气泡。
+- 头像使用昵称首字符。
+- 消息区自动滚动到底部。
+- 输入区包含昵称、内容、字数和提交按钮。
+
+## 3. 提交流程
+
+点击发送后立即创建本地消息并发起请求：
+1. 前端校验昵称至少 2 个字符，内容至少 5 个字符，内容最多 100 个字符。
+2. 本地消息状态先置为 `sending`。
+3. `POST /api/comments` 由 Next Route Handler 代理到 Nest `/v2/comments`。
+4. 成功后消息状态改为 `sent`。
+5. 失败后消息状态改为 `failed`，并展示后端或代理返回的错误文案。
+
+## 4. API 对齐
+
+### Next Route Handler
+
+路径：`POST /api/comments`
+
+职责：
+- 解析前端 JSON 请求。
+- 转发到 `NEST_API_URL/comments`。
+- 上游失败时输出 `[guestbook] ...` 日志。
+- 将上游错误 JSON 或纯文本错误转换为前端可读响应。
+
+### Nest 留言接口
+
+路径：`POST /v2/comments`
+
+调整：
+- `CreateAnonymousCommentDto` 增加可选 `page?: string`。
+- `Comment.externalId` 支持匿名留言 UUID，以字符串写入 MongoDB。
+- `CommentService.findByExternalId` 接受 `string | number`，兼容 GitHub 同步数字 ID。
+
+## 5. 构建输出隔离
+
+Next 配置按环境拆分输出目录：
+- production: `dist/wuh.site.next`
+- development: `dist/wuh.site.next-dev`
+
+这样可以避免开发服务运行时误跑 `next build` 后污染 dev CSS chunk。
+
+## 风险与后续
+
+- `externalId` schema 从 Number 改为 String 后，Mongoose 查询数字 ID 会被 cast 为字符串；历史数字值如果以 Number 形式存在，需要在后续数据迁移中统一。
+- 当前只实现本地会话内消息展示，不拉取数据库历史留言。
+- 当前失败消息只展示错误，不支持一键重试。

--- a/openspec/changes/archive/2026-07-05-P-about-guestbook-chat-ui/proposal.md
+++ b/openspec/changes/archive/2026-07-05-P-about-guestbook-chat-ui/proposal.md
@@ -1,0 +1,39 @@
+# About 页面留言板群聊化改造
+
+## 背景
+
+About 页面新增留言板后，原弹幕式入口和弹窗存在几类问题：
+- 弹幕持续动画在弹窗内播放不够稳定，消息增多后容易卡顿。
+- 弹幕布局不利于回看留言，也不符合“留言板”的长期阅读场景。
+- 发送失败时前端只显示笼统状态，Next / Nest 侧缺少可定位日志。
+- About 页面入口视觉像一个独立功能按钮，与页面中“最近日志”“足迹”等内容模块不协调。
+
+## 目标
+
+- 将留言弹窗从弹幕式浏览改为类似微信群聊的消息流。
+- 点击发送后立即提交留言，并在消息气泡内展示发送中、已发送、发送失败状态。
+- 缓存用户昵称，后续进入时自动带出。
+- 为 `/api/comments` 增加 Next Route Handler 代理，提交失败时输出服务端日志并返回可读错误。
+- 对齐 Nest 留言 DTO / schema，使 `page` 字段与匿名 UUID 留言可正常保存。
+- 重设计 About 页面留言板入口，使其成为 About 页自然的内容 section。
+- 分离 Next dev / build 输出目录，避免生产 build 污染 dev CSS chunk。
+
+## 非目标
+
+- 不新增留言历史拉取与分页。
+- 不实现失败消息重试按钮。
+- 不修改 MongoDB 已有历史数据迁移脚本。
+- 不调整 About 页面其他模块的信息架构。
+
+## 影响范围
+
+- `packages/wuh.site.next/app/about/AboutView.tsx`
+- `packages/wuh.site.next/app/about/components/GuestbookBarrageDialog.tsx`
+- `packages/wuh.site.next/app/about/components/guestbook-barrage.styles.ts`
+- `packages/wuh.site.next/app/about/components/guestbook-barrage.helpers.js`
+- `packages/wuh.site.next/app/about/components/guestbook-barrage.helpers.test.js`
+- `packages/wuh.site.next/app/api/comments/route.ts`
+- `packages/wuh.site.next/next.config.ts`
+- `packages/wuh.site.next/tsconfig.json`
+- `packages/wuh.site.nest/src/modules/comment/*`
+- `packages/shared-contracts/src/index.ts`

--- a/openspec/changes/archive/2026-07-05-P-about-guestbook-chat-ui/specs/guestbook-barrage/spec.md
+++ b/openspec/changes/archive/2026-07-05-P-about-guestbook-chat-ui/specs/guestbook-barrage/spec.md
@@ -1,6 +1,6 @@
 # 留言板群聊弹窗
 
-## Requirements
+## MODIFIED: About 页面留言入口
 
 ### Requirement: About 页面留言板入口
 
@@ -10,6 +10,8 @@
 - **THEN** 系统应展示一个与 About 页面视觉一致的留言入口
 - **AND** 入口应使用聊天语义的头像、标题、预览文案和进入提示
 - **AND** 用户点击入口后应打开居中的留言弹窗
+
+## MODIFIED: 留言弹窗主体验
 
 ### Requirement: 群聊式留言弹窗
 
@@ -21,14 +23,7 @@
 - **AND** 用户新发送的留言应以右侧气泡展示
 - **AND** 消息头像应使用昵称的第一个字符
 
-### Requirement: 输入框字数限制
-
-#### Scenario: 用户输入留言内容
-- **GIVEN** 用户正在弹窗底部输入留言
-- **WHEN** 输入内容长度达到 100 个字符
-- **THEN** 输入框应停止继续增长
-- **AND** 系统应保证不会提交超过 100 个字符的内容
-- **AND** 页面应清晰展示字数状态
+## MODIFIED: 留言提交时机
 
 ### Requirement: 点击发送即提交
 
@@ -40,6 +35,8 @@
 - **AND** 发送中、已发送、发送失败状态应在消息气泡内可见
 - **AND** 失败状态应展示可读错误信息
 
+## MODIFIED: 用户昵称记忆
+
 ### Requirement: 缓存留言昵称
 
 #### Scenario: 用户再次打开留言板
@@ -47,6 +44,8 @@
 - **WHEN** 用户再次打开留言弹窗
 - **THEN** 系统应从本地缓存恢复昵称
 - **AND** 用户仍可修改昵称
+
+## MODIFIED: 留言 API 代理与错误日志
 
 ### Requirement: Next 留言代理
 
@@ -57,6 +56,8 @@
 - **AND** Next 服务端应输出 `[guestbook]` 前缀的错误日志
 - **AND** 前端应在消息气泡中展示该错误信息
 
+## MODIFIED: 留言后端数据契约
+
 ### Requirement: 匿名留言字段对齐
 
 #### Scenario: Nest 接收匿名留言
@@ -65,6 +66,8 @@
 - **THEN** `page` 字段不应被白名单校验拒绝
 - **AND** 匿名留言生成的 UUID externalId 应能保存到 MongoDB
 - **AND** GitHub 同步的数字 externalId 查询应保持兼容
+
+## MODIFIED: Next 构建输出隔离
 
 ### Requirement: dev 与 build 输出目录隔离
 

--- a/openspec/changes/archive/2026-07-05-P-about-guestbook-chat-ui/tasks.md
+++ b/openspec/changes/archive/2026-07-05-P-about-guestbook-chat-ui/tasks.md
@@ -1,0 +1,77 @@
+# 任务清单：About 页面留言板群聊化改造
+
+## Phase 1: 提案与设计
+
+- [x] Task 1: 创建 OpenSpec 提案
+  - 文件: `openspec/changes/2026-07-05-P-about-guestbook-chat-ui/proposal.md`
+  - 预估: 10min
+  - 实际: 8min
+
+- [x] Task 2: 记录技术设计
+  - 文件: `openspec/changes/2026-07-05-P-about-guestbook-chat-ui/design.md`
+  - 预估: 15min
+  - 实际: 12min
+
+## Phase 2: 前端体验改造
+
+- [x] Task 3: 将弹幕弹窗改为群聊式留言弹窗
+  - 文件: `packages/wuh.site.next/app/about/components/GuestbookBarrageDialog.tsx`
+  - 文件: `packages/wuh.site.next/app/about/components/guestbook-barrage.styles.ts`
+  - 预估: 1h
+  - 实际: 45min
+
+- [x] Task 4: 发送后立即提交并展示消息状态
+  - 文件: `packages/wuh.site.next/app/about/components/GuestbookBarrageDialog.tsx`
+  - 文件: `packages/wuh.site.next/app/about/components/guestbook-barrage.helpers.js`
+  - 文件: `packages/wuh.site.next/app/about/components/guestbook-barrage.helpers.test.js`
+  - 预估: 45min
+  - 实际: 35min
+
+- [x] Task 5: 重设计 About 页面留言板入口
+  - 文件: `packages/wuh.site.next/app/about/AboutView.tsx`
+  - 文件: `packages/wuh.site.next/app/about/components/guestbook-barrage.styles.ts`
+  - 预估: 35min
+  - 实际: 25min
+
+## Phase 3: API 与后端修复
+
+- [x] Task 6: 新增 Next 留言代理 route
+  - 文件: `packages/wuh.site.next/app/api/comments/route.ts`
+  - 预估: 30min
+  - 实际: 20min
+
+- [x] Task 7: 对齐 Nest 留言 DTO 与 schema
+  - 文件: `packages/wuh.site.nest/src/modules/comment/dto/comment.dto.ts`
+  - 文件: `packages/wuh.site.nest/src/modules/comment/schemas/comment.schema.ts`
+  - 文件: `packages/wuh.site.nest/src/modules/comment/comment.service.ts`
+  - 文件: `packages/shared-contracts/src/index.ts`
+  - 预估: 30min
+  - 实际: 20min
+
+## Phase 4: 构建与校验
+
+- [x] Task 8: 分离 Next dev / build 输出目录
+  - 文件: `packages/wuh.site.next/next.config.ts`
+  - 文件: `packages/wuh.site.next/tsconfig.json`
+  - 预估: 20min
+  - 实际: 15min
+
+- [x] Task 9: 执行验证
+  - 命令: `./node_modules/.bin/oxlint ...`
+  - 命令: `./node_modules/.bin/nest build`（直接执行曾通过；最后复跑出现本地 SWC/Node 139 与卡住，已中断）
+  - 命令: `node --test packages/wuh.site.next/app/about/components/guestbook-barrage.helpers.test.js`
+  - 预估: 20min
+  - 实际: 15min
+
+## Phase 5: Review 与归档
+
+- [x] Task 10: 代码审查并处理阻塞项
+  - 检查: 需求覆盖、设计一致性、lint、构建、错误可观测性
+  - 预估: 20min
+  - 实际: 15min
+
+- [x] Task 11: 归档 OpenSpec change
+  - 文件: `openspec/specs/guestbook-barrage/spec.md`
+  - 文件: `openspec/changes/archive/2026-07-05-P-about-guestbook-chat-ui/`
+  - 预估: 15min
+  - 实际: 10min

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -9,24 +9,26 @@ context: |
 
 rules:
   proposal:
-    - 变更名称必须使用 {project-name}_{yyyy_MM_DD} 格式，如 测试任务_2024_06_01, {project-name} 可选用英文或中文, 但建议使用中文以提高可读性，可以从对话中的项目名称中提取，或者是需求详情中提炼
+    - "变更名称必须使用 YYYY-MM-DD-{P|B}-{kebab-case} 格式，如 2026-07-05-P-add-comment-api"
+    - "P 表示新需求，B 表示新 bug"
+    - "kebab-case 从需求标题或 bug 摘要中提炼，使用英文小写和连字符"
     - 明确说明变更的原因和范围
     - 标注影响的前端/后端包
     - 文档输出使用中文
   branch:
-    - 功能分支命名: {issue-number}-{type}-{short-description}
-    - type 取值: feat / fix / refactor / docs / chore, 对应 conventional commits 类型
+    - "功能分支命名: {issue-number}-{type}-{short-description}"
+    - "type 取值: feat / fix / refactor / docs / chore, 对应 conventional commits 类型"
     - short-description 使用中文, 2-5 字, 连字符分隔 (如 移动端隐藏邮箱图标)
     - issue-number 来自 GitHub Issue, propose 阶段生成 .openspec.yaml 时必须写入 issue 字段
-    - 示例: 153-fix-移动端隐藏邮箱图标, 142-feat-代码拆分优化
+    - "示例: 153-fix-移动端隐藏邮箱图标, 142-feat-代码拆分优化"
   specs:
-    - 使用 ## ADDED / ## MODIFIED / ## REMOVED / ## RENAMED 标记需求变更
+    - "使用 ## ADDED / ## MODIFIED / ## REMOVED / ## RENAMED 标记需求变更"
     - 每个 Requirement 用 GIVEN/WHEN/THEN 格式描述场景
     - 文档输出使用中文
   design:
     - 技术方案需说明对现有模块的影响
     - 涉及 API 变更时，注明接口路径、请求/响应格式
-    - 文档输出使用中文  
+    - 文档输出使用中文
   tasks:
     - 按 Phase 组织，每个 task 控制在 2 小时以内
     - 标注每个 task 涉及的文件路径

--- a/packages/shared-contracts/src/index.ts
+++ b/packages/shared-contracts/src/index.ts
@@ -85,6 +85,7 @@ export interface CreateAnonymousCommentDto {
   nickname: string;
   email?: string;
   content: string;
+  page?: string;
 }
 
 export interface QueryCommentDto {

--- a/packages/wuh.site.nest/src/modules/comment/comment.service.ts
+++ b/packages/wuh.site.nest/src/modules/comment/comment.service.ts
@@ -60,7 +60,7 @@ export class CommentService {
       .exec();
   }
 
-  async findByExternalId(externalId: number): Promise<CommentDocument | null> {
+  async findByExternalId(externalId: string | number): Promise<CommentDocument | null> {
     return this.commentModel.findOne({ externalId }).exec();
   }
 

--- a/packages/wuh.site.nest/src/modules/comment/dto/comment.dto.ts
+++ b/packages/wuh.site.nest/src/modules/comment/dto/comment.dto.ts
@@ -18,6 +18,11 @@ export class CreateAnonymousCommentDto implements ICreateAnonymousCommentDto {
   @IsString()
   @MinLength(5)
   content: string;
+
+  @ApiPropertyOptional({ description: 'Page identifier (e.g. about-guestbook)' })
+  @IsString()
+  @IsOptional()
+  page?: string;
 }
 
 export class QueryCommentDto implements IQueryCommentDto {

--- a/packages/wuh.site.nest/src/modules/comment/schemas/comment.schema.ts
+++ b/packages/wuh.site.nest/src/modules/comment/schemas/comment.schema.ts
@@ -6,9 +6,9 @@ export type CommentDocument = HydratedDocument<Comment>;
 
 @Schema({ timestamps: true })
 export class Comment {
-  @ApiProperty({ description: 'GitHub comment id' })
-  @Prop({ required: true, unique: true })
-  externalId: number;
+  @ApiProperty({ description: 'External comment id (GitHub id or anonymous UUID)' })
+  @Prop({ type: String, required: true, unique: true })
+  externalId: string | number;
 
   @ApiProperty({ description: 'Issue id (MongoDB ObjectId)' })
   @Prop({ required: true })

--- a/packages/wuh.site.next/app/about/AboutView.tsx
+++ b/packages/wuh.site.next/app/about/AboutView.tsx
@@ -71,7 +71,7 @@ const AboutView = ({ profile, repos: _ }: AboutViewProps) => {
       <Hero>
         <HeroLabel>About · 吴尒红</HeroLabel>
         <HeroTitle>输出节奏总览</HeroTitle>
-        <HeroSub>不要停止脚步, 每一天都要进步</HeroSub>
+        <HeroSub>不断创新, 无限进步</HeroSub>
       </Hero>
 
       {/* 2. 关于我 */}
@@ -195,7 +195,7 @@ const AboutView = ({ profile, repos: _ }: AboutViewProps) => {
         </TimelineList>
       </section>
 
-      <section style={{ marginBottom: 'var(--space-2xl)' }}>
+      <section>
         <SectionHeader>
           <SectionLabel>足迹</SectionLabel>
         </SectionHeader>
@@ -204,7 +204,12 @@ const AboutView = ({ profile, repos: _ }: AboutViewProps) => {
         </div>
       </section>
 
-      <GuestbookBarrageDialog />
+      <section>
+        <SectionHeader>
+          <SectionLabel>留言板</SectionLabel>
+        </SectionHeader>
+        <GuestbookBarrageDialog />
+      </section>
 
       <Dialog
         open={Boolean(activeContactConfig)}

--- a/packages/wuh.site.next/app/about/components/GuestbookBarrageDialog.tsx
+++ b/packages/wuh.site.next/app/about/components/GuestbookBarrageDialog.tsx
@@ -1,119 +1,202 @@
 'use client'
 
-import { FormEvent, useMemo, useState } from 'react'
+import { FormEvent, useEffect, useMemo, useRef, useState } from 'react'
 import Dialog from '@wuh.site/components/dialog'
-import { IconArrowRight, IconBars, IconClose } from '@wuh.site/components/icons'
+import { IconArrowRight } from '@wuh.site/components/icons'
 import {
-  BarrageItem,
-  BarragePanel,
+  ChatAvatar,
+  ChatBubble,
+  ChatFeed,
+  ChatMessageMeta,
+  ChatRow,
+  ChatStatus,
   Composer,
   ComposerActions,
   ComposerMeta,
   ComposerTextArea,
-  ComposerToggle,
-  ComposerToggleLabel,
   GuestbookBody,
   GuestbookHeader,
-  GuestbookLayout,
-  GuestbookList,
-  GuestbookListItem,
-  GuestbookListMeta,
-  GuestbookListText,
-  GuestbookListTitle,
   GuestbookPanel,
   GuestbookStage,
   GuestbookSubtitle,
   GuestbookTitle,
   GuestbookTrigger,
+  GuestbookTriggerAvatar,
+  GuestbookTriggerAvatars,
+  GuestbookTriggerCopy,
+  GuestbookTriggerCta,
   GuestbookTriggerLabel,
+  GuestbookTriggerPreview,
+  GuestbookTriggerTitle,
   GuestbookWrapper,
   LayoutBadge,
 } from './guestbook-barrage.styles'
 import {
   clampGuestbookContent,
-  flushGuestbookDrafts,
-  queueGuestbookDraft,
-  resolveGuestbookLayout,
+  createGuestbookMessage,
 } from './guestbook-barrage.helpers.js'
 
 const MAX_LENGTH = 100
+const MIN_NICKNAME_LENGTH = 2
+const MIN_CONTENT_LENGTH = 5
+const NICKNAME_STORAGE_KEY = 'wuh.site.guestbook.nickname'
 
-type GuestbookDraft = {
+type GuestbookMessage = {
   id: string
   nickname: string
   content: string
   createdAt: string
-  status: 'pending'
+  status: 'sending' | 'sent' | 'failed'
+  error?: string
 }
 
-const mockBarrage = [
-  { id: 1, text: '这里会显示弹幕内容，像 B 站一样飘过屏幕。', lane: 0, tone: 'soft' },
-  { id: 2, text: '弹幕支持更轻快的浏览方式。', lane: 1, tone: 'accent' },
-  { id: 3, text: '列表默认隐藏，点击按钮才展开。', lane: 2, tone: 'soft' },
-  { id: 4, text: '桌面端左右并列，移动端上下布局。', lane: 3, tone: 'accent' },
-]
+type ChatMessage = {
+  id: string
+  nickname: string
+  content: string
+  time: string
+  mine?: boolean
+  status?: GuestbookMessage['status']
+  error?: string
+}
+
+const sampleMessages = [
+  { id: 'sample-1', nickname: '吴尒红', content: '来这里打个招呼，顺便看看最近在折腾什么。', time: '刚刚' },
+  { id: 'sample-1', nickname: '吴尒红', content: '欢迎留言，短句也很好。这里会像群聊一样一条条留住。', time: '2 分钟前' },
+  { id: 'sample-3', nickname: '远方的朋友', content: '这个聊天式留言板比弹幕更容易回看。', time: '5 分钟前' },
+] as const
+
+const getAvatarText = (nickname: string) => nickname.trim().charAt(0).toUpperCase() || '?'
+const formatDraftTime = (createdAt: string) =>
+  new Intl.DateTimeFormat('zh-CN', { hour: '2-digit', minute: '2-digit' }).format(new Date(createdAt))
 
 export default function GuestbookBarrageDialog() {
   const [open, setOpen] = useState(false)
-  const [showList, setShowList] = useState(false)
   const [content, setContent] = useState('')
   const [nickname, setNickname] = useState('')
-  const [draftQueue, setDraftQueue] = useState<GuestbookDraft[]>([])
+  const [localMessages, setLocalMessages] = useState<GuestbookMessage[]>([])
   const [submitting, setSubmitting] = useState(false)
+  const feedRef = useRef<HTMLDivElement>(null)
 
   const clamped = useMemo(() => clampGuestbookContent(content), [content])
-  const canSubmit = nickname.trim().length > 0 && clamped.length > 0
-  const layout = resolveGuestbookLayout(false, showList)
+  const trimmedNickname = nickname.trim()
+  const trimmedContent = clamped.value.trim()
+  const failedCount = localMessages.filter((item) => item.status === 'failed').length
+  const canSubmit = trimmedNickname.length >= MIN_NICKNAME_LENGTH && trimmedContent.length >= MIN_CONTENT_LENGTH
+  const chatMessages = useMemo<ChatMessage[]>(() => {
+    const samples = sampleMessages.map((item) => ({ ...item, mine: item.nickname === 'Shadow' }))
+    const messages = localMessages.map((item) => ({
+      id: item.id,
+      content: item.content,
+      nickname: item.nickname,
+      time: formatDraftTime(item.createdAt),
+      mine: true,
+      status: item.status,
+      error: item.error,
+    }))
+
+    return [...samples, ...messages]
+  }, [localMessages])
+
+  useEffect(() => {
+    try {
+      const cachedNickname = window.localStorage.getItem(NICKNAME_STORAGE_KEY)
+      if (cachedNickname) setNickname(cachedNickname)
+    } catch {
+      // localStorage can be unavailable in hardened browsing modes.
+    }
+  }, [])
+
+  useEffect(() => {
+    feedRef.current?.scrollTo({ top: feedRef.current.scrollHeight, behavior: 'smooth' })
+  }, [chatMessages.length, open])
 
   const handleChange = (value: string) => {
     const next = clampGuestbookContent(value)
     setContent(next.value)
   }
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleNicknameChange = (value: string) => {
+    const next = value.slice(0, 20)
+    setNickname(next)
+    const trimmed = next.trim()
+    if (trimmed) {
+      try {
+        window.localStorage.setItem(NICKNAME_STORAGE_KEY, trimmed)
+      } catch {
+        // Ignore storage failures; the current input still works.
+      }
+    }
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     if (!canSubmit || submitting) return
 
-    const nextQueue = queueGuestbookDraft(draftQueue, {
+    const nextMessages = createGuestbookMessage(localMessages, {
       nickname,
       content,
-    }) as GuestbookDraft[]
+    }) as GuestbookMessage[]
+    const currentMessage = nextMessages[nextMessages.length - 1]
+    if (!currentMessage) return
 
-    setDraftQueue(nextQueue)
-    setNickname('')
+    setLocalMessages(nextMessages)
+    handleNicknameChange(nickname)
     setContent('')
-  }
+    setSubmitting(true)
 
-  const handleClose = async () => {
-    if (!submitting && draftQueue.length > 0) {
-      setSubmitting(true)
-      const remaining = await flushGuestbookDrafts(draftQueue, async (draft) => {
-        const res = await fetch('/api/comments', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ nickname: draft.nickname, content: draft.content, page: 'about-guestbook' }),
-        })
-        if (!res.ok) throw new Error('Failed to submit draft')
+    try {
+      const res = await fetch('/api/comments', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          nickname: currentMessage.nickname,
+          content: currentMessage.content,
+          page: 'about-guestbook',
+        }),
       })
-      setDraftQueue(remaining as GuestbookDraft[])
+
+      const data = await res.json().catch(() => null)
+      if (!res.ok) {
+        const message =
+          (data && typeof data === 'object' && 'message' in data && String(data.message)) ||
+          `留言提交失败 (${res.status})`
+        throw new Error(message)
+      }
+      setLocalMessages((prev) =>
+        prev.map((item) => (item.id === currentMessage.id ? { ...item, status: 'sent', error: undefined } : item))
+      )
+    } catch (error) {
+      const message = error instanceof Error ? error.message : '留言提交失败'
+      setLocalMessages((prev) =>
+        prev.map((item) => (item.id === currentMessage.id ? { ...item, status: 'failed', error: message } : item))
+      )
+    } finally {
       setSubmitting(false)
     }
-    setOpen(false)
   }
 
   return (
     <>
       <GuestbookTrigger type='button' onClick={() => setOpen(true)}>
-        <IconBars />
-        <GuestbookTriggerLabel>
-          <strong>留言板</strong>
-          <span>打开弹幕弹窗</span>
-        </GuestbookTriggerLabel>
+        <GuestbookTriggerAvatars aria-hidden='true'>
+          <GuestbookTriggerAvatar>W</GuestbookTriggerAvatar>
+          <GuestbookTriggerAvatar>你</GuestbookTriggerAvatar>
+        </GuestbookTriggerAvatars>
+        <GuestbookTriggerCopy>
+          <GuestbookTriggerLabel>Guestbook</GuestbookTriggerLabel>
+          <GuestbookTriggerTitle>给我留一句话</GuestbookTriggerTitle>
+          <GuestbookTriggerPreview>最近看到的想法、建议或者招呼，都可以放在这里。</GuestbookTriggerPreview>
+        </GuestbookTriggerCopy>
+        <GuestbookTriggerCta>
+          <span>进入</span>
+          <IconArrowRight />
+        </GuestbookTriggerCta>
       </GuestbookTrigger>
 
       <Dialog
         open={open}
-        onClose={handleClose}
+        onClose={() => setOpen(false)}
         title='留言板'
         width='min(1120px, calc(100vw - 32px))'
         height='min(720px, calc(100vh - 80px))'
@@ -122,88 +205,67 @@ export default function GuestbookBarrageDialog() {
           <GuestbookHeader>
             <div>
               <GuestbookTitle>留言板</GuestbookTitle>
-              <GuestbookSubtitle>先本地出弹幕，关闭时再统一提交，避免频繁请求。</GuestbookSubtitle>
+              <GuestbookSubtitle>像群聊一样留下一句话，点击发送后会立即提交。</GuestbookSubtitle>
             </div>
-            <LayoutBadge>{showList ? '双栏展示' : '弹幕优先'}</LayoutBadge>
+            <LayoutBadge>{submitting ? '发送中' : failedCount ? `${failedCount} 条失败` : '群聊模式'}</LayoutBadge>
           </GuestbookHeader>
 
           <GuestbookBody>
-            <GuestbookLayout $layout={layout}>
-              <GuestbookPanel>
-                <GuestbookStage>
-                  <BarragePanel>
-                    {mockBarrage.map((item) => (
-                      <BarrageItem key={item.id} $lane={item.lane} $tone={item.tone}>
-                        {item.text}
-                      </BarrageItem>
-                    ))}
-                  </BarragePanel>
-                </GuestbookStage>
+            <GuestbookPanel>
+              <GuestbookStage>
+                <ChatFeed ref={feedRef}>
+                  {chatMessages.map((item) => (
+                    <ChatRow key={item.id} $mine={Boolean(item.mine)}>
+                      <ChatAvatar aria-hidden='true'>{getAvatarText(item.nickname)}</ChatAvatar>
+                      <ChatBubble $mine={Boolean(item.mine)}>
+                        <ChatMessageMeta>
+                          <span>{item.nickname}</span>
+                          <time>{item.time}</time>
+                        </ChatMessageMeta>
+                        <p>{item.content}</p>
+                        {item.status === 'sending' && <ChatStatus>发送中...</ChatStatus>}
+                        {item.status === 'sent' && <ChatStatus>已发送</ChatStatus>}
+                        {item.status === 'failed' && (
+                          <ChatStatus $tone='error'>{item.error || '发送失败'}</ChatStatus>
+                        )}
+                      </ChatBubble>
+                    </ChatRow>
+                  ))}
+                </ChatFeed>
+              </GuestbookStage>
 
-                <Composer onSubmit={handleSubmit}>
-                  <input
-                    value={nickname}
-                    placeholder='你的昵称'
-                    maxLength={20}
-                    onChange={(event) => setNickname(event.target.value)}
-                  />
-                  <ComposerTextArea
-                    value={content}
-                    maxLength={MAX_LENGTH}
-                    rows={1}
-                    placeholder='发一条弹幕...'
-                    onChange={(event) => handleChange(event.target.value)}
-                  />
-                  <ComposerMeta $overLimit={clamped.remaining === 0 && clamped.length > 0}>
-                    <span>
-                      {clamped.length} / {MAX_LENGTH}
-                    </span>
-                    <span>{clamped.remaining} 字可输入</span>
-                  </ComposerMeta>
-                  <ComposerActions>
-                    <ComposerToggle
-                      type='button'
-                      aria-pressed={showList}
-                      onClick={() => setShowList((prev) => !prev)}
-                    >
-                      <IconBars />
-                      <ComposerToggleLabel>{showList ? '收起列表' : '展开列表'}</ComposerToggleLabel>
-                    </ComposerToggle>
-                    <button type='submit' disabled={!canSubmit || submitting}>
-                      <IconArrowRight />
-                      发送
-                    </button>
-                  </ComposerActions>
-                </Composer>
-              </GuestbookPanel>
-
-              {showList && (
-                <GuestbookList>
-                  <GuestbookListTitle>
-                    留言列表
-                    <button type='button' aria-label='关闭留言列表' onClick={() => setShowList(false)}>
-                      <IconClose />
-                    </button>
-                  </GuestbookListTitle>
-                  <GuestbookListItem>
-                    {draftQueue.map((item) => (
-                      <li key={item.id}>
-                        <GuestbookListMeta>
-                          <strong>{item.nickname}</strong>
-                          <span>待提交</span>
-                        </GuestbookListMeta>
-                        <GuestbookListText>{item.content}</GuestbookListText>
-                      </li>
-                    ))}
-                    {!draftQueue.length && (
-                      <li>
-                        <GuestbookListText>还没有待提交的留言，先发一条弹幕吧。</GuestbookListText>
-                      </li>
-                    )}
-                  </GuestbookListItem>
-                </GuestbookList>
-              )}
-            </GuestbookLayout>
+              <Composer onSubmit={handleSubmit}>
+                <input
+                  value={nickname}
+                  placeholder='你的昵称'
+                  maxLength={20}
+                  onChange={(event) => handleNicknameChange(event.target.value)}
+                />
+                <ComposerTextArea
+                  value={content}
+                  maxLength={MAX_LENGTH}
+                  rows={2}
+                  placeholder='在群里说点什么...'
+                  onChange={(event) => handleChange(event.target.value)}
+                />
+                <ComposerMeta $overLimit={clamped.remaining === 0 && clamped.length > 0}>
+                  <span>
+                    {trimmedNickname.length < MIN_NICKNAME_LENGTH
+                      ? '昵称至少 2 个字符'
+                      : trimmedContent.length < MIN_CONTENT_LENGTH
+                        ? '内容至少 5 个字符'
+                        : `当前昵称：${trimmedNickname}`}
+                  </span>
+                  <span>{clamped.length} / {MAX_LENGTH}</span>
+                </ComposerMeta>
+                <ComposerActions>
+                  <button type='submit' disabled={!canSubmit || submitting}>
+                    <IconArrowRight />
+                    发送
+                  </button>
+                </ComposerActions>
+              </Composer>
+            </GuestbookPanel>
           </GuestbookBody>
         </GuestbookWrapper>
       </Dialog>

--- a/packages/wuh.site.next/app/about/components/guestbook-barrage.helpers.js
+++ b/packages/wuh.site.next/app/about/components/guestbook-barrage.helpers.js
@@ -9,35 +9,16 @@ export function clampGuestbookContent(input) {
   }
 }
 
-export function resolveGuestbookLayout(isMobile, showList) {
-  if (isMobile) return 'stack'
-  return showList ? 'split' : 'barrage'
-}
-
-export function queueGuestbookDraft(queue, draft) {
-  const nickname = String(draft?.nickname ?? '').trim()
-  const content = clampGuestbookContent(draft?.content ?? '').value.trim()
+export function createGuestbookMessage(queue, message) {
+  const nickname = String(message?.nickname ?? '').trim()
+  const content = clampGuestbookContent(message?.content ?? '').value.trim()
   if (!nickname || !content) return queue
 
   return queue.concat({
-    id: draft?.id ?? `${queue.length + 1}`,
+    id: message?.id ?? `${queue.length + 1}`,
     nickname,
     content,
-    createdAt: draft?.createdAt ?? new Date().toISOString(),
-    status: 'pending',
+    createdAt: message?.createdAt ?? new Date().toISOString(),
+    status: message?.status ?? 'sending',
   })
-}
-
-export async function flushGuestbookDrafts(queue, submitDraft) {
-  const remaining = []
-
-  for (const draft of queue) {
-    try {
-      await submitDraft(draft)
-    } catch {
-      remaining.push(draft)
-    }
-  }
-
-  return remaining
 }

--- a/packages/wuh.site.next/app/about/components/guestbook-barrage.helpers.test.js
+++ b/packages/wuh.site.next/app/about/components/guestbook-barrage.helpers.test.js
@@ -2,9 +2,7 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import {
   clampGuestbookContent,
-  flushGuestbookDrafts,
-  queueGuestbookDraft,
-  resolveGuestbookLayout,
+  createGuestbookMessage,
 } from './guestbook-barrage.helpers.js'
 
 test('clampGuestbookContent truncates input to 100 characters', () => {
@@ -14,35 +12,14 @@ test('clampGuestbookContent truncates input to 100 characters', () => {
   assert.equal(result.remaining, 0)
 })
 
-test('resolveGuestbookLayout uses split layout only when list is open', () => {
-  assert.equal(resolveGuestbookLayout(false, false), 'barrage')
-  assert.equal(resolveGuestbookLayout(false, true), 'split')
-  assert.equal(resolveGuestbookLayout(true, true), 'stack')
-})
-
-test('queueGuestbookDraft appends a local draft without submitting immediately', () => {
-  const queue = queueGuestbookDraft([], {
+test('createGuestbookMessage appends a local sending message', () => {
+  const queue = createGuestbookMessage([], {
     nickname: 'Shadow',
-    content: '先本地弹幕展示',
+    content: '先本地聊天展示',
   })
 
   assert.equal(queue.length, 1)
   assert.equal(queue[0].nickname, 'Shadow')
-  assert.equal(queue[0].content, '先本地弹幕展示')
-  assert.equal(queue[0].status, 'pending')
-})
-
-test('flushGuestbookDrafts submits queued drafts and clears the queue', async () => {
-  const drafts = queueGuestbookDraft([], {
-    nickname: 'Shadow',
-    content: '关闭时统一提交',
-  })
-
-  const seen = []
-  const next = await flushGuestbookDrafts(drafts, async (draft) => {
-    seen.push(draft.content)
-  })
-
-  assert.deepEqual(seen, ['关闭时统一提交'])
-  assert.equal(next.length, 0)
+  assert.equal(queue[0].content, '先本地聊天展示')
+  assert.equal(queue[0].status, 'sending')
 })

--- a/packages/wuh.site.next/app/about/components/guestbook-barrage.styles.ts
+++ b/packages/wuh.site.next/app/about/components/guestbook-barrage.styles.ts
@@ -1,46 +1,36 @@
-import styled, { keyframes } from '@wuh.site/components/styled'
-
-const floatLeft = keyframes`
-  from {
-    transform: translateX(18px);
-    opacity: 0;
-  }
-  to {
-    transform: translateX(0);
-    opacity: 1;
-  }
-`
+import styled from '@wuh.site/components/styled'
 
 export const GuestbookTrigger = styled.button`
-  display: inline-flex;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
-  gap: 12px;
+  gap: 14px;
   width: 100%;
-  margin-top: var(--space-md);
-  padding: 14px 18px;
-  border: 1px solid color-mix(in oklab, var(--primary-color) 18%, var(--normal-300) 82%);
-  border-radius: var(--radius-card);
+  padding: 14px 16px;
+  border: 1px solid color-mix(in oklab, var(--normal-300) 44%, transparent);
+  border-left: 3px solid var(--accent-color);
+  border-radius: 8px;
   background:
-    radial-gradient(circle at 100% 0%, color-mix(in oklab, var(--primary-color) 8%, transparent), transparent 52%),
+    linear-gradient(90deg, color-mix(in oklab, var(--accent-color) 7%, transparent), transparent 42%),
     var(--background-100);
   color: var(--text-primary);
+  text-align: left;
   cursor: pointer;
-  box-shadow: var(--elevation-soft);
   transition:
-    transform 0.2s ease,
-    box-shadow 0.2s ease,
+    background 0.2s ease,
     border-color 0.2s ease;
 
   svg {
-    width: 20px;
-    height: 20px;
+    width: 15px;
+    height: 15px;
     flex-shrink: 0;
   }
 
   &:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 12px 24px color-mix(in oklab, var(--primary-color) 12%, transparent);
-    border-color: color-mix(in oklab, var(--primary-color) 36%, var(--normal-300) 64%);
+    background:
+      linear-gradient(90deg, color-mix(in oklab, var(--accent-color) 10%, transparent), transparent 48%),
+      var(--background-200);
+    border-color: color-mix(in oklab, var(--accent-color) 26%, var(--normal-300) 74%);
   }
 
   &:focus-visible {
@@ -49,24 +39,87 @@ export const GuestbookTrigger = styled.button`
   }
 
   @media (prefers-color-scheme: dark) {
-    background: color-mix(in oklab, var(--normal-700) 30%, var(--background-100));
+    background:
+      linear-gradient(90deg, color-mix(in oklab, var(--accent-color) 10%, transparent), transparent 44%),
+      color-mix(in oklab, var(--normal-700) 22%, var(--background-100));
     border-color: color-mix(in oklab, var(--normal-700) 45%, transparent);
+  }
+
+  @media (max-width: 520px) {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
   }
 `
 
-export const GuestbookTriggerLabel = styled.span`
+export const GuestbookTriggerAvatars = styled.span`
+  display: flex;
+  align-items: center;
+  min-width: 54px;
+`
+
+export const GuestbookTriggerAvatar = styled.span`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 2px solid var(--background-100);
+  background: color-mix(in oklab, var(--accent-color) 18%, var(--background-100));
+  color: var(--accent-color);
+  font-size: 12px;
+  font-weight: 700;
+
+  & + & {
+    margin-left: -10px;
+    background: color-mix(in oklab, var(--primary-color) 14%, var(--background-100));
+    color: var(--primary-color);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    border-color: var(--background-100);
+  }
+`
+
+export const GuestbookTriggerCopy = styled.span`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 2px;
+  gap: 4px;
+  min-width: 0;
+`
 
-  strong {
-    font-size: 0.98rem;
-  }
+export const GuestbookTriggerLabel = styled.span`
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  color: var(--accent-color);
+`
 
-  span {
-    font-size: 0.84rem;
-    color: var(--text-secondary);
+export const GuestbookTriggerTitle = styled.strong`
+  color: var(--text-primary);
+  font-size: 14px;
+  font-weight: 700;
+`
+
+export const GuestbookTriggerPreview = styled.span`
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.55;
+`
+
+export const GuestbookTriggerCta = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  white-space: nowrap;
+
+  @media (max-width: 520px) {
+    grid-column: 2;
+    margin-top: 2px;
   }
 `
 
@@ -92,13 +145,13 @@ export const GuestbookHeader = styled.header`
 
 export const GuestbookTitle = styled.h3`
   margin: 0;
-  font-size: 1.05rem;
+  font-size: 0.98rem;
 `
 
 export const GuestbookSubtitle = styled.p`
   margin: 6px 0 0;
   color: var(--text-secondary);
-  font-size: 0.88rem;
+  font-size: 0.78rem;
   line-height: 1.6;
 `
 
@@ -111,7 +164,7 @@ export const LayoutBadge = styled.span`
   border-radius: 999px;
   background: color-mix(in oklab, var(--primary-color) 10%, transparent);
   color: var(--primary-color);
-  font-size: 0.8rem;
+  font-size: 0.72rem;
   font-weight: 600;
   white-space: nowrap;
 `
@@ -122,23 +175,12 @@ export const GuestbookBody = styled.div`
   padding-top: 16px;
 `
 
-export const GuestbookLayout = styled.div<{ $layout: 'barrage' | 'split' | 'stack' }>`
-  display: grid;
-  grid-template-columns: ${({ $layout }) => ($layout === 'split' ? 'minmax(0, 2fr) minmax(280px, 1fr)' : '1fr')};
-  gap: 16px;
-  height: 100%;
-  min-height: 0;
-
-  @media (max-width: 640px) {
-    grid-template-columns: 1fr;
-  }
-`
-
 export const GuestbookPanel = styled.section`
   display: flex;
   flex-direction: column;
   min-height: 0;
-  gap: 14px;
+  height: 100%;
+  gap: 12px;
 `
 
 export const GuestbookStage = styled.div`
@@ -146,71 +188,147 @@ export const GuestbookStage = styled.div`
   flex: 1;
   min-height: 320px;
   overflow: hidden;
-  border-radius: 20px;
+  border-radius: 14px;
   border: 1px solid color-mix(in oklab, var(--normal-300) 35%, transparent);
   background:
-    radial-gradient(circle at top left, color-mix(in oklab, var(--primary-color) 9%, transparent), transparent 38%),
-    linear-gradient(180deg, color-mix(in oklab, var(--background-100) 96%, var(--primary-color) 4%), var(--background-100));
+    linear-gradient(90deg, color-mix(in oklab, var(--normal-300) 15%, transparent) 1px, transparent 1px),
+    linear-gradient(180deg, color-mix(in oklab, var(--background-200) 58%, transparent), var(--background-100));
+  background-size: 22px 22px, auto;
 
   @media (prefers-color-scheme: dark) {
     border-color: color-mix(in oklab, var(--normal-700) 50%, transparent);
     background:
-      radial-gradient(circle at top left, color-mix(in oklab, var(--primary-color) 12%, transparent), transparent 38%),
+      linear-gradient(90deg, color-mix(in oklab, var(--normal-700) 18%, transparent) 1px, transparent 1px),
       linear-gradient(180deg, color-mix(in oklab, var(--normal-700) 18%, var(--background-100)), var(--background-100));
+    background-size: 22px 22px, auto;
   }
 `
 
-export const BarragePanel = styled.div`
+export const ChatFeed = styled.div`
   position: absolute;
   inset: 0;
-  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow: auto;
   padding: 18px;
+  scroll-behavior: smooth;
+
+  @media (max-width: 640px) {
+    padding: 14px 12px;
+  }
 `
 
-export const BarrageItem = styled.div<{ $lane: number; $tone: 'soft' | 'accent' }>`
-  position: absolute;
-  top: ${({ $lane }) => `${18 + $lane * 18}%`};
-  left: 0;
-  max-width: 88%;
-  padding: 8px 12px;
-  border-radius: 999px;
-  background: ${({ $tone }) =>
-    $tone === 'accent'
-      ? 'color-mix(in oklab, var(--primary-color) 14%, rgba(255,255,255,0.86))'
-      : 'color-mix(in oklab, var(--background-100) 88%, transparent)'};
+export const ChatRow = styled.div<{ $mine: boolean }>`
+  display: flex;
+  flex-direction: ${({ $mine }) => ($mine ? 'row-reverse' : 'row')};
+  align-items: flex-start;
+  gap: 9px;
+`
+
+export const ChatAvatar = styled.span`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  flex: 0 0 34px;
+  border-radius: 10px;
+  background: color-mix(in oklab, var(--primary-color) 14%, var(--background-100));
+  color: var(--primary-color);
+  border: 1px solid color-mix(in oklab, var(--primary-color) 18%, transparent);
+  font-size: 0.82rem;
+  font-weight: 700;
+`
+
+export const ChatBubble = styled.div<{ $mine: boolean }>`
+  position: relative;
+  max-width: min(68%, 620px);
+  padding: 9px 11px 8px;
+  border-radius: ${({ $mine }) => ($mine ? '12px 2px 12px 12px' : '2px 12px 12px 12px')};
+  background: ${({ $mine }) =>
+    $mine
+      ? 'color-mix(in oklab, var(--primary-color) 14%, var(--background-100))'
+      : 'color-mix(in oklab, var(--background-100) 92%, transparent)'};
   color: var(--text-primary);
-  border: 1px solid color-mix(in oklab, var(--normal-300) 25%, transparent);
-  box-shadow: 0 10px 18px rgba(0, 0, 0, 0.06);
-  animation: ${floatLeft} 260ms ease-out both;
+  border: 1px solid
+    ${({ $mine }) =>
+      $mine
+        ? 'color-mix(in oklab, var(--primary-color) 22%, transparent)'
+        : 'color-mix(in oklab, var(--normal-300) 34%, transparent)'};
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.04);
+
+  p {
+    margin: 5px 0 0;
+    font-size: 0.86rem;
+    line-height: 1.62;
+    overflow-wrap: anywhere;
+  }
+
+  @media (max-width: 640px) {
+    max-width: calc(100% - 44px);
+  }
 
   @media (prefers-color-scheme: dark) {
-    background: ${({ $tone }) =>
-      $tone === 'accent'
+    background: ${({ $mine }) =>
+      $mine
         ? 'color-mix(in oklab, var(--primary-color) 18%, var(--background-100))'
         : 'color-mix(in oklab, var(--normal-700) 26%, var(--background-100))'};
-    border-color: color-mix(in oklab, var(--normal-700) 45%, transparent);
-    box-shadow: 0 12px 20px rgba(0, 0, 0, 0.22);
+    border-color: ${({ $mine }) =>
+      $mine
+        ? 'color-mix(in oklab, var(--primary-color) 30%, transparent)'
+        : 'color-mix(in oklab, var(--normal-700) 45%, transparent)'};
+    box-shadow: 0 12px 20px rgba(0, 0, 0, 0.16);
   }
+`
+
+export const ChatMessageMeta = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-secondary);
+  font-size: 0.72rem;
+
+  span {
+    max-width: 10em;
+    overflow: hidden;
+    color: var(--text-primary);
+    font-weight: 700;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  time {
+    white-space: nowrap;
+  }
+`
+
+export const ChatStatus = styled.span<{ $tone?: 'error' }>`
+  display: inline-flex;
+  margin-top: 6px;
+  color: ${({ $tone }) => ($tone === 'error' ? 'var(--primary-color)' : 'var(--text-secondary)')};
+  font-size: 0.7rem;
 `
 
 export const Composer = styled.form`
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  padding: 14px 16px;
-  border-radius: 18px;
+  gap: 8px;
+  padding: 12px;
+  border-radius: 14px;
   border: 1px solid color-mix(in oklab, var(--normal-300) 26%, transparent);
   background: color-mix(in oklab, var(--background-100) 96%, var(--primary-color) 4%);
 
   input {
     width: 100%;
-    min-height: 44px;
+    min-height: 38px;
     border: 1px solid color-mix(in oklab, var(--normal-300) 40%, transparent);
-    border-radius: 14px;
-    padding: 12px 14px;
+    border-radius: 10px;
+    padding: 8px 11px;
     background: var(--background-100);
     color: var(--text-primary);
     font: inherit;
+    font-size: 0.82rem;
     line-height: 1.5;
     outline: none;
   }
@@ -232,14 +350,15 @@ export const Composer = styled.form`
 
 export const ComposerTextArea = styled.textarea`
   width: 100%;
-  min-height: 44px;
+  min-height: 38px;
   resize: none;
   border: 1px solid color-mix(in oklab, var(--normal-300) 40%, transparent);
-  border-radius: 14px;
-  padding: 12px 14px;
+  border-radius: 10px;
+  padding: 8px 11px;
   background: var(--background-100);
   color: var(--text-primary);
   font: inherit;
+  font-size: 0.82rem;
   line-height: 1.5;
   outline: none;
 
@@ -259,7 +378,7 @@ export const ComposerMeta = styled.div<{ $overLimit: boolean }>`
   justify-content: space-between;
   gap: 12px;
   color: ${({ $overLimit }) => ($overLimit ? 'var(--primary-color)' : 'var(--text-secondary)')};
-  font-size: 0.8rem;
+  font-size: 0.72rem;
 `
 
 export const ComposerActions = styled.div`
@@ -273,13 +392,14 @@ export const ComposerActions = styled.div`
     align-items: center;
     justify-content: center;
     gap: 8px;
-    min-height: 40px;
-    padding: 0 14px;
+    min-height: 36px;
+    padding: 0 12px;
     border-radius: 999px;
     border: 1px solid color-mix(in oklab, var(--normal-300) 45%, transparent);
     background: var(--background-100);
     color: var(--text-primary);
     cursor: pointer;
+    font-size: 0.82rem;
   }
 
   button:disabled {
@@ -291,92 +411,4 @@ export const ComposerActions = styled.div`
     width: 16px;
     height: 16px;
   }
-`
-
-export const ComposerToggle = styled.button`
-  border-color: color-mix(in oklab, var(--primary-color) 18%, var(--normal-300) 82%) !important;
-  color: var(--primary-color) !important;
-`
-
-export const ComposerToggleLabel = styled.span`
-  font-weight: 600;
-`
-
-export const GuestbookList = styled.aside`
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-  border-radius: 20px;
-  border: 1px solid color-mix(in oklab, var(--normal-300) 32%, transparent);
-  background: var(--background-100);
-  overflow: hidden;
-
-  @media (prefers-color-scheme: dark) {
-    border-color: color-mix(in oklab, var(--normal-700) 45%, transparent);
-  }
-`
-
-export const GuestbookListTitle = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 14px 16px;
-  border-bottom: 1px solid color-mix(in oklab, var(--normal-300) 26%, transparent);
-  font-weight: 700;
-
-  button {
-    width: 34px;
-    height: 34px;
-    border-radius: 10px;
-    border: none;
-    background: color-mix(in oklab, var(--normal-300) 18%, transparent);
-    color: var(--text-primary);
-    cursor: pointer;
-  }
-
-  svg {
-    width: 16px;
-    height: 16px;
-  }
-`
-
-export const GuestbookListItem = styled.ul`
-  list-style: none;
-  padding: 8px;
-  margin: 0;
-  overflow: auto;
-  min-height: 0;
-
-  li {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    padding: 12px;
-    border-radius: 16px;
-    background: color-mix(in oklab, var(--background-200) 66%, transparent);
-  }
-
-  li + li {
-    margin-top: 8px;
-  }
-`
-
-export const GuestbookListMeta = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  font-size: 0.8rem;
-  color: var(--text-secondary);
-
-  strong {
-    color: var(--text-primary);
-  }
-`
-
-export const GuestbookListText = styled.p`
-  margin: 0;
-  color: var(--text-primary);
-  line-height: 1.65;
 `

--- a/packages/wuh.site.next/app/api/comments/route.ts
+++ b/packages/wuh.site.next/app/api/comments/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse, type NextRequest } from 'next/server'
+
+const nestApiUrl =
+  process.env.NEST_API_URL ||
+  (process.env.NODE_ENV === 'production' ? 'http://nest:3200/v2' : 'http://localhost:3200/v2')
+
+const toErrorMessage = (value: unknown) => {
+  if (value instanceof Error) return value.message
+  if (typeof value === 'string') return value
+  return '留言服务暂时不可用'
+}
+
+const parseResponseBody = (text: string) => {
+  if (!text) return {}
+
+  try {
+    return JSON.parse(text)
+  } catch {
+    return { message: text }
+  }
+}
+
+const logGuestbookError = (message: string, meta: Record<string, unknown>) => {
+  process.stderr.write(`[guestbook] ${message} ${JSON.stringify(meta)}\n`)
+}
+
+export async function POST(request: NextRequest) {
+  let payload: unknown
+
+  try {
+    payload = await request.json()
+  } catch {
+    return NextResponse.json({ message: '请求内容不是合法 JSON' }, { status: 400 })
+  }
+
+  try {
+    const upstream = await fetch(`${nestApiUrl}/comments`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+    const text = await upstream.text()
+    const data = parseResponseBody(text)
+
+    if (!upstream.ok) {
+      logGuestbookError('comment submit failed', {
+        status: upstream.status,
+        data,
+      })
+      return NextResponse.json(data, { status: upstream.status })
+    }
+
+    return NextResponse.json(data, { status: upstream.status })
+  } catch (error) {
+    const message = toErrorMessage(error)
+    logGuestbookError('comment submit proxy failed', {
+      message,
+      nestApiUrl,
+    })
+    return NextResponse.json({ message }, { status: 502 })
+  }
+}

--- a/packages/wuh.site.next/next.config.ts
+++ b/packages/wuh.site.next/next.config.ts
@@ -1,11 +1,12 @@
 import type { NextConfig } from "next";
 
+const isProduction = process.env.NODE_ENV === 'production';
 const nestApiUrl =
   process.env.NEST_API_URL ||
-  (process.env.NODE_ENV === 'production' ? 'http://nest:3200/v2' : 'http://localhost:3200/v2');
+  (isProduction ? 'http://nest:3200/v2' : 'http://localhost:3200/v2');
 
 const nextConfig: NextConfig = {
-  distDir: './dist/wuh.site.next',
+  distDir: isProduction ? './dist/wuh.site.next' : './dist/wuh.site.next-dev',
   typescript: {
     ignoreBuildErrors: true,
   },

--- a/packages/wuh.site.next/tsconfig.json
+++ b/packages/wuh.site.next/tsconfig.json
@@ -38,11 +38,12 @@
     "allowJs": true
   },
   "include": [
+    "./dist/wuh.site.next/types/**/*.ts",
     "app/**/*",
     "components/**/*",
     "next-env.d.ts",
     "types/**/*",
-    "./dist/wuh.site.next/types/**/*.ts"
+    "./dist/wuh.site.next-dev/types/**/*.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## 变更内容
- 将 About 留言板从弹幕体验改为群聊式留言弹窗
- 优化 About 页面留言板入口 UI，使其融入页面 section 节奏
- 点击发送后立即提交留言，并展示发送中、已发送、失败状态
- 新增 Next /api/comments 代理 route，提交失败时返回可读错误并输出 [guestbook] 日志
- 对齐 Nest 留言 DTO 与 externalId schema，支持 page 字段和匿名 UUID
- 分离 Next dev/build 输出目录，避免 build 污染 dev 静态资源
- 归档 OpenSpec 变更并更新 guestbook-barrage 主规范
- 添加 AGENTS.md 协作说明

## 验证
- oxlint: About 留言组件、API route、next.config 通过
- node --test: guestbook-barrage.helpers.test.js 通过
- nest build: 直接执行曾通过；后续复跑出现本地 SWC/Node 139 与卡住，已记录在 OpenSpec tasks