### PR TITLE
fix: fetch homepage data at runtime after build (#184)

### DIFF
--- a/openspec/INDEX.md
+++ b/openspec/INDEX.md
@@ -68,6 +68,11 @@
 - **需求:** Dialog遮罩层, Dialog圆角和间距, Dialog移动端底部弹出, Dialog动画(弹性缓动+退出), 纸张风视觉
 - **路径:** `openspec/specs/contact-dialog/spec.md`
 
+## homepage-data — 首页数据获取
+- **关键词:** 首页, 数据获取, Server Component, 构建后, force-dynamic, 空数据
+- **需求:** Homepage fetches data at runtime after production build, Homepage logs server data fetch failures
+- **路径:** `openspec/specs/homepage-data/spec.md`
+
 ## icon-system — 图标系统
 - **关键词:** 图标, lucide-react, Outline风格, SVG, 组件库
 - **需求:** 统一Outline图标风格, 统一图标接口, 移除混用fill/stroke旧图标, Brand图标风格对齐
@@ -89,8 +94,8 @@
 - **路径:** `openspec/specs/redesign-error-pages/spec.md`
 
 ## build-config — 构建配置
-- **关键词:** 构建, 环境变量, dotenv, MongoDB, health check, sync
-- **需求:** dotenv环境变量加载, sync:init使用完整NestJS启动, MongooseModule异步工厂, health检查, sync仅同步open issues
+- **关键词:** 构建, 环境变量, dotenv, MongoDB, health check, sync, Docker, NEST_API_URL
+- **需求:** dotenv环境变量加载, sync:init使用完整NestJS启动, MongooseModule异步工厂, health检查, sync仅同步open issues, Production server API fallback uses Docker service name
 - **路径:** `openspec/specs/build-config/spec.md`
 
 ## code-split — 代码拆分

--- a/openspec/changes/archive/2026-07-05-B-fix-homepage-build-empty-data/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-05-B-fix-homepage-build-empty-data/.openspec.yaml
@@ -1,0 +1,6 @@
+project: x.wuh.site
+change: 2026-07-05-B-fix-homepage-build-empty-data
+date: 2026-07-05
+type: B
+status: applied
+issue: https://github.com/stack-wuh/x.wuh.site/issues/184

--- a/openspec/changes/archive/2026-07-05-B-fix-homepage-build-empty-data/design.md
+++ b/openspec/changes/archive/2026-07-05-B-fix-homepage-build-empty-data/design.md
@@ -1,0 +1,27 @@
+# 设计文档
+
+## 架构
+
+首页仍由 Server Component 获取数据，但不能在构建阶段把失败结果固化为静态 HTML。修复分两层：
+
+1. `createService.ts` 使用和 `next.config.ts` 一致的 API base fallback：生产环境默认 `http://nest:3200/v2`，开发环境默认 `http://localhost:3200/v2`。
+2. 首页声明 `dynamic = 'force-dynamic'`，确保数据在运行时获取，而不是构建时预渲染成空数据。
+
+## 技术选型
+
+| 维度 | 选择 | 理由 |
+|------|------|------|
+| 渲染策略 | `force-dynamic` | 避免构建期 API 不可达时固化空数据 |
+| API fallback | production 使用 `http://nest:3200/v2` | Docker compose 中 Next 访问 Nest 应使用服务名 |
+| 错误诊断 | `console.error` 服务端日志 | 保持最小改动，便于定位线上空数据 |
+
+## API 设计（如涉及）
+
+不新增 API。
+
+## 影响分析
+
+- **新增依赖:** 无。
+- **破坏性变更:** 无。
+- **向后兼容:** 开发环境仍默认访问 `localhost:3200/v2`。
+- **性能影响:** 首页从静态预渲染变为运行时渲染；各请求仍使用现有 revalidate 配置参与 Next fetch 缓存。

--- a/openspec/changes/archive/2026-07-05-B-fix-homepage-build-empty-data/proposal.md
+++ b/openspec/changes/archive/2026-07-05-B-fix-homepage-build-empty-data/proposal.md
@@ -1,0 +1,24 @@
+# 修复构建后首页数据模块为空
+
+## 背景
+
+生产构建后，首页多个服务端数据模块显示为空。首页数据来自内容 API、仓库 API、微信读书 API，但这些请求在构建阶段失败后被转换为空数组，导致空数据被写入构建产物。
+
+## 目标
+
+- 首页不在 `next build` 阶段固化空数据。
+- 服务端 API base 在生产环境默认指向 Docker 内部 Nest 服务。
+- 首页数据请求失败时输出可诊断日志。
+
+## 非目标（明确不做）
+
+- 不改后端 API 业务逻辑。
+- 不改首页视觉结构。
+- 不引入新的缓存系统。
+
+## 影响范围
+
+- `packages/hooks/useFetch/createService.ts` — 修正生产环境 API base fallback。
+- `packages/wuh.site.next/app/page.tsx` — 强制首页运行时动态渲染，并记录请求失败日志。
+- `openspec/specs/build-config/spec.md` — 记录生产 API base fallback 规则。
+- `openspec/specs/homepage-data/spec.md` — 记录首页运行时数据获取规则。

--- a/openspec/changes/archive/2026-07-05-B-fix-homepage-build-empty-data/specs/build-config/spec.md
+++ b/openspec/changes/archive/2026-07-05-B-fix-homepage-build-empty-data/specs/build-config/spec.md
@@ -1,0 +1,22 @@
+# Spec: 构建配置
+
+## ADDED
+
+### Requirement: Production server API fallback uses Docker service name
+- **GIVEN** Next.js 服务运行在生产环境且未显式配置 `NEST_API_URL`
+- **WHEN** Server Component 或 Route Handler 通过共享 service 请求 Nest API
+- **THEN** 默认 API base 应为 `http://nest:3200/v2`
+
+---
+
+## MODIFIED
+
+### Requirement: None
+- 本次不修改既有构建配置需求。
+
+---
+
+## REMOVED
+
+### Requirement: None
+- 本次不移除既有构建配置需求。

--- a/openspec/changes/archive/2026-07-05-B-fix-homepage-build-empty-data/specs/homepage-data/spec.md
+++ b/openspec/changes/archive/2026-07-05-B-fix-homepage-build-empty-data/specs/homepage-data/spec.md
@@ -1,0 +1,28 @@
+# Spec: 首页数据获取
+
+## ADDED
+
+### Requirement: Homepage fetches data at runtime after production build
+- **GIVEN** 应用完成生产构建并启动
+- **WHEN** 用户访问首页
+- **THEN** 首页应在运行时请求内容、仓库和微信读书数据
+- **AND** 不应使用构建阶段 API 失败产生的空数组作为最终页面数据
+
+### Requirement: Homepage logs server data fetch failures
+- **GIVEN** 首页任一服务端数据请求失败
+- **WHEN** 页面返回 fallback 空数组
+- **THEN** 服务端日志应包含失败模块名和错误信息
+
+---
+
+## MODIFIED
+
+### Requirement: None
+- 本次不修改既有首页数据需求。
+
+---
+
+## REMOVED
+
+### Requirement: None
+- 本次不移除既有首页数据需求。

--- a/openspec/changes/archive/2026-07-05-B-fix-homepage-build-empty-data/tasks.md
+++ b/openspec/changes/archive/2026-07-05-B-fix-homepage-build-empty-data/tasks.md
@@ -1,0 +1,40 @@
+# 任务清单
+
+## Phase 1: 回归测试
+
+### Task 1: 覆盖 API base fallback
+
+- [x] **文件:** `packages/hooks/useFetch/apiBase.test.mjs`
+- [x] 验证生产环境默认 API base 为 `http://nest:3200/v2`。
+- [x] 验证开发环境默认 API base 为 `http://localhost:3200/v2`。
+- [x] **预计耗时:** 30 分钟
+- [x] **实际耗时:** 20 分钟
+- [x] **验证:** `node packages/hooks/useFetch/apiBase.test.mjs`
+
+## Phase 2: 修复实现
+
+### Task 2: 修正 API base 与首页动态渲染
+
+- [x] **文件:** `packages/hooks/useFetch/createService.ts`
+- [x] 将生产 fallback 改为 `http://nest:3200/v2`。
+- [x] **文件:** `packages/wuh.site.next/app/page.tsx`
+- [x] 增加 `dynamic = 'force-dynamic'`。
+- [x] 首页数据请求失败时输出服务端日志。
+- [x] **预计耗时:** 30 分钟
+- [x] **实际耗时:** 20 分钟
+- [ ] **验证:** `PATH=/Users/wuhong/.nvm/versions/node/v20.20.2/bin:$PATH node_modules/.bin/tsc --noEmit --incremental false --pretty false` 当前最终复验 SIGSEGV
+
+## 验收
+
+- [x] 构建阶段不会把首页 API 失败结果固化为空数据。
+- [x] 生产环境默认 API base 指向 `http://nest:3200/v2`。
+- [x] 开发环境默认 API base 仍指向 `http://localhost:3200/v2`。
+- [x] 首页请求失败时能从服务端日志看到具体模块和错误。
+
+
+## 验证备注
+
+- `node packages/hooks/useFetch/apiBase.test.mjs` 通过。
+- `packages/wuh.site.next/node_modules/.bin/oxlint packages/wuh.site.next/app/page.tsx packages/hooks/useFetch/createService.ts packages/hooks/useFetch/apiBase.ts` 通过。
+- `PATH=/Users/wuhong/.nvm/versions/node/v20.20.2/bin:$PATH node_modules/.bin/tsc --noEmit --incremental false --pretty false` 曾通过一次，最终复验连续 SIGSEGV，需在稳定本机/CI 环境复验。
+- 本地 `next build` 在下载字体/编译阶段长时间无输出后手动中断；需要 CI 或有稳定网络的本机环境复验完整生产构建。

--- a/openspec/specs/build-config/spec.md
+++ b/openspec/specs/build-config/spec.md
@@ -31,3 +31,8 @@
 - **WHEN** 执行增量/全量同步
 - **THEN** 仅拉取 `state: 'open'` 的 issues
 - **AND** 已关闭的 issues 不同步
+
+### Requirement: Production server API fallback uses Docker service name
+- **GIVEN** Next.js 服务运行在生产环境且未显式配置 `NEST_API_URL`
+- **WHEN** Server Component 或 Route Handler 通过共享 service 请求 Nest API
+- **THEN** 默认 API base 应为 `http://nest:3200/v2`

--- a/openspec/specs/homepage-data/spec.md
+++ b/openspec/specs/homepage-data/spec.md
@@ -1,0 +1,14 @@
+# 首页数据获取
+
+## ADDED
+
+### Requirement: Homepage fetches data at runtime after production build
+- **GIVEN** 应用完成生产构建并启动
+- **WHEN** 用户访问首页
+- **THEN** 首页应在运行时请求内容、仓库和微信读书数据
+- **AND** 不应使用构建阶段 API 失败产生的空数组作为最终页面数据
+
+### Requirement: Homepage logs server data fetch failures
+- **GIVEN** 首页任一服务端数据请求失败
+- **WHEN** 页面返回 fallback 空数组
+- **THEN** 服务端日志应包含失败模块名和错误信息

--- a/packages/hooks/useFetch/apiBase.test.mjs
+++ b/packages/hooks/useFetch/apiBase.test.mjs
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import vm from 'node:vm'
+
+const source = readFileSync(new URL('./apiBase.ts', import.meta.url), 'utf8')
+const js = source
+  .replace(/export type ApiBaseEnv = \{[\s\S]*?\}\n\n/, '')
+  .replace('export function resolveApiBase(env: ApiBaseEnv = process.env): string {', 'function resolveApiBase(env = process.env) {')
+  .replace(/export const API_BASE = resolveApiBase\(\)\n?/, '')
+
+const context = { process: { env: {} } }
+vm.runInNewContext(`${js}\nthis.resolveApiBase = resolveApiBase`, context)
+const { resolveApiBase } = context
+
+assert.equal(resolveApiBase({ NEST_API_URL: 'https://api.example.com/v2', NODE_ENV: 'production' }), 'https://api.example.com/v2')
+assert.equal(resolveApiBase({ NEST_API_URL: '  https://api.example.com/v2  ', NODE_ENV: 'production' }), 'https://api.example.com/v2')
+assert.equal(resolveApiBase({ NODE_ENV: 'production' }), 'http://nest:3200/v2')
+assert.equal(resolveApiBase({ NODE_ENV: 'development' }), 'http://localhost:3200/v2')
+assert.equal(resolveApiBase({}), 'http://localhost:3200/v2')
+
+console.log('apiBase fallback tests passed')

--- a/packages/hooks/useFetch/apiBase.ts
+++ b/packages/hooks/useFetch/apiBase.ts
@@ -1,0 +1,13 @@
+export type ApiBaseEnv = {
+  NEST_API_URL?: string
+  NODE_ENV?: string
+}
+
+export function resolveApiBase(env: ApiBaseEnv = process.env): string {
+  const explicitApiUrl = env.NEST_API_URL?.trim()
+  if (explicitApiUrl) return explicitApiUrl
+
+  return env.NODE_ENV === 'production' ? 'http://nest:3200/v2' : 'http://localhost:3200/v2'
+}
+
+export const API_BASE = resolveApiBase()

--- a/packages/hooks/useFetch/createService.ts
+++ b/packages/hooks/useFetch/createService.ts
@@ -1,7 +1,6 @@
 import { fetcher, type QueryRecord, type RequestOptions, type FetchResult, type FetchError } from './fetcher'
 import { useRequest } from 'ahooks'
-
-const API_BASE = process.env.NEST_API_URL || 'http://localhost:3200/v2'
+import { API_BASE } from './apiBase'
 
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
 

--- a/packages/wuh.site.next/app/page.tsx
+++ b/packages/wuh.site.next/app/page.tsx
@@ -5,6 +5,13 @@ import HomeView from './HomeView'
 
 const SITE_URL = 'https://wuh.site'
 
+export const dynamic = 'force-dynamic'
+
+function logHomeFetchError(moduleName: string, error: unknown) {
+  const message = error instanceof Error ? error.message : JSON.stringify(error)
+  process.stderr.write(`[home] Failed to fetch ${moduleName}: ${message}\n`)
+}
+
 export const metadata: Metadata = {
   title: 'wuh.site · 朝朝如念',
   description: '基于 Next.js 的个人站，汇集 GitHub 项目、文章与工具',
@@ -25,7 +32,8 @@ export const metadata: Metadata = {
 }
 
 async function getRepos(): Promise<RepoDto[]> {
-  const { data } = await reposService.getAll.server({ revalidate: 3600 })
+  const { data, error } = await reposService.getAll.server({ revalidate: 3600 })
+  if (error) logHomeFetchError('repos', error)
   if (!data) return []
   return (data as any).repos.slice(0, 6) as RepoDto[]
 }
@@ -41,19 +49,21 @@ const mapContentToPost = (item: ContentItem): PostListItem => ({
 })
 
 async function getFeaturedIssues(): Promise<PostListItem[]> {
-  const { data } = await contentService.getPosts.server({
+  const { data, error } = await contentService.getPosts.server({
     query: { limit: '6', state: 'open' },
     revalidate: 1800,
   })
+  if (error) logHomeFetchError('featured posts', error)
   if (!data) return []
   return (data as any).data.map(mapContentToPost) as PostListItem[]
 }
 
 async function getYearlySummaries(): Promise<PostListItem[]> {
-  const { data } = await contentService.getPosts.server({
+  const { data, error } = await contentService.getPosts.server({
     query: { limit: '50', state: 'open' },
     revalidate: 1800,
   })
+  if (error) logHomeFetchError('yearly summaries', error)
   if (!data) return []
   return (data as any).data
     .map(mapContentToPost)
@@ -62,10 +72,11 @@ async function getYearlySummaries(): Promise<PostListItem[]> {
 }
 
 async function getWereadBooks(): Promise<WereadBook[]> {
-  const { data } = await wereadService.getBooks.server({
+  const { data, error } = await wereadService.getBooks.server({
     query: { page: '5', limit: '6' },
     revalidate: 3600,
   })
+  if (error) logHomeFetchError('weread books', error)
   if (!data) return []
   return ((data as any).data || []) as WereadBook[]
 }


### PR DESCRIPTION
## Summary

- Force homepage runtime rendering so build-time API failures are not baked into static homepage data.
- Align shared server API fallback with Docker production networking: `http://nest:3200/v2`.
- Add homepage server-side fetch diagnostics for empty fallback cases.
- Archive OpenSpec bug change `2026-07-05-B-fix-homepage-build-empty-data`.

## Verification

- `node packages/hooks/useFetch/apiBase.test.mjs` passed.
- `PATH=/Users/wuhong/.nvm/versions/node/v20.20.2/bin:$PATH packages/wuh.site.next/node_modules/.bin/oxlint packages/wuh.site.next/app/page.tsx packages/hooks/useFetch/createService.ts packages/hooks/useFetch/apiBase.ts` passed.
- `git diff --check` passed.

## Local Environment Notes

- `node_modules/.bin/tsc --noEmit` passed once earlier, but final repeated local runs hit Node/V8 `SIGSEGV`; needs CI confirmation.
- `next build` started only with network escalation but then stalled locally after several minutes; needs CI or stable local network/build environment confirmation.

Closes #184
