### PR TITLE
feat: 博客多标签过滤 (#186)

### DIFF
--- a/openspec/INDEX.md
+++ b/openspec/INDEX.md
@@ -9,8 +9,8 @@
 - **路径:** `openspec/specs/components/spec.md`
 
 ## content-api — 内容 API
-- **关键词:** 内容API, 分页, REST, 博客, 项目, 404, 查询参数, 相邻文章, 封面图, metadata.cover
-- **需求:** Paginated response format, Post not found returns 404, Query parameter type coercion, Labels comma-separated, findAll returns PaginatedResult, Post detail includes prev/next adjacent posts, Post detail derives cover from first content image, Post detail falls back to markdown first image
+- **关键词:** 内容API, 分页, REST, 博客, 项目, 404, 查询参数, labels, AND查询, 相邻文章, 封面图, metadata.cover
+- **需求:** Paginated response format, Post not found returns 404, Query parameter type coercion, Labels comma-separated, Multiple labels query uses AND semantics, findAll returns PaginatedResult, Post detail includes prev/next adjacent posts, Post detail derives cover from first content image, Post detail falls back to markdown first image
 - **路径:** `openspec/specs/content-api/spec.md`
 
 ## rss — RSS 订阅
@@ -54,8 +54,8 @@
 - **路径:** `openspec/specs/blog-code-highlighting/spec.md`
 
 ## blog-category-filter — 博客分类查询
-- **关键词:** 博客列表, 分类查询, labels, 分页, GitHub Issues
-- **需求:** 博客列表支持分类查询, 分类筛选状态可分享, 分类入口展示完整 open 标签汇总, 分类筛选与分页联动, 切换分类重置分页, GitHub Issues 风格过滤条, 博客列表分页 URL
+- **关键词:** 博客列表, 分类查询, labels, 多标签, AND查询, 分页, GitHub Issues, 主题色
+- **需求:** 博客列表支持分类查询, 多标签 AND 分类查询, 分类筛选状态可分享, 多标签筛选状态可分享, 分类入口展示完整 open 标签汇总, 分类数量文案, 分类筛选与分页联动, 多标签分类筛选与分页联动, 切换分类重置分页, 多个筛选 token 可单独移除, GitHub Issues 风格过滤条, 博客列表分页 URL
 - **路径:** `openspec/specs/blog-category-filter/spec.md`
 
 ## blog-scroll-flicker-fix — 滚动闪屏修复

--- a/openspec/changes/archive/2026-07-05-P-blog-multi-label-filter/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-05-P-blog-multi-label-filter/.openspec.yaml
@@ -1,0 +1,6 @@
+project: x.wuh.site
+change: 2026-07-05-P-blog-multi-label-filter
+date: 2026-07-05
+type: P
+status: proposed
+issue: https://github.com/stack-wuh/x.wuh.site/issues/186

--- a/openspec/changes/archive/2026-07-05-P-blog-multi-label-filter/design.md
+++ b/openspec/changes/archive/2026-07-05-P-blog-multi-label-filter/design.md
@@ -1,0 +1,111 @@
+# 设计文档
+
+## 架构
+
+本次沿用现有博客列表的 Server Component 数据获取方式。`/blog/page.tsx` 从 URL 读取一个或多个 `labels` 参数，规范化为 `string[]` 后请求内容 API；`BlogListView` 只负责渲染过滤条、标签菜单、已选 token、列表和分页链接。
+
+```
+/blog?labels=javascript&labels=react
+        |
+        v
+page.tsx 解析 activeLabels: string[]
+        |
+        v
+GET /content/posts?state=open&labels=javascript&labels=react
+        |
+        v
+Nest content controller 使用 { labels: { $all: [...] } }
+        |
+        v
+BlogListView 渲染多 token 与可追加标签菜单
+```
+
+## 技术选型
+
+| 维度 | 选择 | 理由 |
+|------|------|------|
+| 多标签语义 | AND，同时包含全部已选标签 | 符合筛选条件叠加的直觉，避免多个 token 被误解为精确筛选但实际放宽结果 |
+| URL 表达 | 优先支持重复查询参数 `labels=a&labels=b`，兼容逗号分隔输入 | Next searchParams 已支持 `string | string[]`，兼容后端 DTO 的 comma-separated or array 说明 |
+| UI 状态 | 多个 token + 单独移除 | 用户能清楚看到当前筛选条件，并逐个回退 |
+| 样式策略 | 使用 `--accent-color`、`--primary-color`、`--background-100` 的 `color-mix` | 与现有主题系统一致，不引入新主题 token |
+
+## 数据模型（如涉及）
+
+不新增数据库字段。现有 `Content.labels: string[]` 继续作为查询依据。
+
+前端将 active label 状态从单值扩展为数组：
+
+```ts
+type Props = {
+  activeLabels: string[]
+  availableLabels: ContentLabelSummary[]
+}
+```
+
+## API 设计（如涉及）
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `/content/posts` | 当存在多个 `labels` 查询参数时，返回同时包含全部 labels 的 open 博客 |
+| GET | `/content/labels` | 保持现有 open labels 汇总接口不变 |
+
+**请求示例:**
+
+```json
+{
+  "page": "1",
+  "limit": "10",
+  "state": "open",
+  "labels": ["javascript", "react"]
+}
+```
+
+**查询语义:**
+
+```ts
+dbQuery.labels = { $all: ['javascript', 'react'] }
+```
+
+单个 label 与现有行为保持一致；多个 label 从“任一匹配”调整为“全部匹配”。
+
+## 组件/模块设计
+
+### Blog page
+
+职责：解析 URL 查询参数、请求文章列表和标签汇总。
+
+- 新增 `toLabelParams(value)`，输出去重后的 `string[]`。
+- 同时支持 `?labels=a&labels=b` 与 `?labels=a,b`。
+- 请求 posts 时传入 labels 数组或逗号分隔字符串，保持 shared-contracts endpoint 可序列化。
+
+### BlogListView
+
+职责：展示博客列表、分类过滤条和分页器。
+
+- `buildBlogUrl(page, labels)` 生成保留多标签的 URL。
+- 点击未选标签时追加到当前 labels，并重置到第 1 页。
+- 点击已选 token 的关闭按钮时只移除该标签；移除最后一个标签后回到 `/blog`。
+- 下拉项文案显示 `name(+count)`；外部已选 token 只显示标签名，active 项仍可点击并保持当前筛选。
+- `FilterSummary` 在存在已选标签时显示当前 AND 查询结果数，例如选中 `javascript(+8)` 和 `vue(+3)` 后如果交集结果为 2 篇，则显示 `Labels(+2)`；未选中任何标签时显示 `Labels`。
+- 过滤条不展示 `open posts` 或 `filtered by` 结果提示文案。
+
+### Content controller
+
+职责：将查询参数转换为 MongoDB 查询条件。
+
+- 当 `labels` 非空时使用 `{ labels: { $all: labels } }`。
+- 保持 `state=open` 与分页参数逻辑不变。
+
+## 响应式策略（如涉及）
+
+| 断点 | 行为 |
+|------|------|
+| >= 768px | 过滤条横向展示，`Labels(+n)` 和多个 token 尽量同行展示 |
+| < 768px | 过滤条允许换行，token 保持可点击区域，不挤压文章列表 |
+
+## 影响分析
+
+- **新增依赖:** 无。
+- **破坏性变更:** 多 labels 查询从 OR 改为 AND；单 label 查询无变化。
+- **向后兼容:** 继续兼容单个 `labels=<label>` URL；无筛选 URL 不变；逗号分隔输入可被解析。
+- **性能影响:** MongoDB 已有 `labels` 索引，`$all` 查询可复用数组索引；多个 label 条件可能减少结果集，分页成本不增加。

--- a/openspec/changes/archive/2026-07-05-P-blog-multi-label-filter/proposal.md
+++ b/openspec/changes/archive/2026-07-05-P-blog-multi-label-filter/proposal.md
@@ -1,0 +1,31 @@
+# 博客多标签过滤体验优化
+
+## 背景
+
+当前博客列表页已经提供 `Labels` 分类入口，并展示 open 博客 labels 汇总，但筛选状态仍是单标签。用户无法叠加多个 label 精确查找同时包含多类主题的文章。
+
+过滤条视觉也存在两个体验问题：标签汇总数量与标签名分离，阅读成本较高；过滤条背景色与主题色不够一致，active/hover/token 状态的主题感不统一。
+
+## 目标
+
+- 支持博客列表多 label 查询，多个 label 之间采用 AND 语义，即文章必须同时包含所有已选标签。
+- 分类入口和标签选项展示数量提示：标签项显示为 `javascript(+8)`，已选标签时入口显示当前 AND 查询结果数，例如 `Labels(+2)`。
+- 已选标签以多个纯标签名 token 展示，可单独移除某个标签，也可回到无筛选状态。
+- 移除过滤条里的结果提示文案，例如 `6 open posts filtered by`。
+- 过滤条、下拉、active、hover、token 背景色统一使用主题色相关 CSS 变量。
+
+## 非目标（明确不做）
+
+- 不实现 OR 语义的多标签查询。
+- 不新增标签管理、排序切换、全文搜索或服务端标签颜色存储。
+- 不改博客详情页文章内容渲染、文章卡片列表结构或分页器组件 API。
+
+## 影响范围
+
+- `packages/wuh.site.next/app/blog/page.tsx` — 解析多个 `labels` 查询参数，并传递给列表请求与视图组件。
+- `packages/wuh.site.next/app/blog/BlogListView.tsx` — 支持多选标签 URL 生成、多个筛选 token、标签数量文案。
+- `packages/wuh.site.next/app/blog/styles/index.ts` — 统一过滤条主题色背景、active/hover/token 状态样式。
+- `packages/wuh.site.nest/src/modules/content/content.controller.ts` — 将多 label 查询语义调整为 AND。
+- `packages/wuh.site.nest/src/modules/content/content.controller.spec.ts` — 覆盖多 label AND 查询条件。
+- `openspec/specs/blog-category-filter/spec.md` — 更新博客分类查询交互规范。
+- `openspec/specs/content-api/spec.md` — 更新内容 API labels 查询语义。

--- a/openspec/changes/archive/2026-07-05-P-blog-multi-label-filter/specs/blog-category-filter/spec.md
+++ b/openspec/changes/archive/2026-07-05-P-blog-multi-label-filter/specs/blog-category-filter/spec.md
@@ -1,0 +1,55 @@
+# Spec: 博客分类查询
+
+## ADDED
+
+### Requirement: 多标签 AND 分类查询
+- **GIVEN** 用户访问博客列表页
+- **WHEN** 用户选择多个 label 作为分类筛选条件
+- **THEN** 页面 URL 包含全部已选 labels 查询参数
+- **AND** 列表仅展示同时包含全部已选 labels 的 open 状态博客文章
+
+### Requirement: 多个筛选 token 可单独移除
+- **GIVEN** 用户处于 `/blog?labels=javascript&labels=react`
+- **WHEN** 用户移除 `react` token
+- **THEN** 页面跳转到仅保留 `javascript` 的筛选 URL
+- **AND** 当最后一个 token 被移除时页面回到 `/blog`
+- **AND** 外部已选 token 只展示标签名
+
+### Requirement: 分类数量文案
+- **GIVEN** open 状态博客包含 labels 汇总
+- **WHEN** 用户打开博客列表页的分类过滤条
+- **THEN** 每个分类选项以 `label(+count)` 格式展示名称和文章数量
+- **AND** 外部已选 token 不展示文章数量
+- **AND** 当用户选择一个或多个标签时，分类入口展示当前 AND 查询结果数，例如 `Labels(+2)`
+- **AND** 当用户没有选择标签时，分类入口展示 `Labels`
+
+---
+
+## MODIFIED
+
+### Requirement: 分类筛选状态可分享
+- **GIVEN** 用户访问 `/blog?labels=javascript&labels=react`
+- **WHEN** 页面服务端渲染并请求博客列表数据
+- **THEN** 请求参数包含 `state=open` 和全部 labels
+- **AND** 页面展示当前全部筛选 token
+
+### Requirement: 分类筛选与分页联动
+- **GIVEN** 用户处于 `/blog?labels=javascript&labels=react`
+- **WHEN** 用户点击分页器进入第 2 页
+- **THEN** 目标 URL 保留全部已选 labels 并包含 `page=2`
+- **AND** 当前多标签筛选不会丢失
+
+### Requirement: GitHub Issues 风格过滤条
+- **GIVEN** 博客列表页渲染
+- **WHEN** 用户查看标题下方区域
+- **THEN** 页面展示 GitHub Issues 风格的分类过滤条
+- **AND** 过滤条包含 `Labels` 或 `Labels(+n)` 入口和当前筛选 token
+- **AND** 过滤条背景、active、hover、token 状态与站点主题色保持一致
+- **AND** 过滤条不展示 `open posts` 或 `filtered by` 结果提示文案
+
+---
+
+## REMOVED
+
+### Requirement: 无
+- 本次不移除既有需求。

--- a/openspec/changes/archive/2026-07-05-P-blog-multi-label-filter/specs/content-api/spec.md
+++ b/openspec/changes/archive/2026-07-05-P-blog-multi-label-filter/specs/content-api/spec.md
@@ -1,0 +1,26 @@
+# Spec: 内容 API
+
+## ADDED
+
+### Requirement: 多 labels 查询使用 AND 语义
+- **GIVEN** 内容列表接口收到多个 `labels` 查询条件
+- **WHEN** 服务端构造数据库查询条件
+- **THEN** 查询条件使用数组全部匹配语义
+- **AND** 返回结果中的每篇文章都同时包含全部指定 labels
+
+---
+
+## MODIFIED
+
+### Requirement: Labels comma-separated
+- **GIVEN** 客户端请求内容列表接口
+- **WHEN** `labels` 以逗号分隔字符串或重复查询参数传入
+- **THEN** 服务端将其规范化为 label 数组
+- **AND** 多个 label 按 AND 语义过滤内容
+
+---
+
+## REMOVED
+
+### Requirement: 无
+- 本次不移除既有需求。

--- a/openspec/changes/archive/2026-07-05-P-blog-multi-label-filter/tasks.md
+++ b/openspec/changes/archive/2026-07-05-P-blog-multi-label-filter/tasks.md
@@ -1,0 +1,75 @@
+# 任务清单
+
+## Phase 1: API 查询语义
+
+### Task 1: 调整多 label 查询为 AND
+
+- [x] **文件:** `packages/wuh.site.nest/src/modules/content/content.controller.ts`
+- [x] 将 `labels` 查询从 `$in` 改为 `$all`。
+- [x] 保持单 label、无 label、`state=open` 查询行为不变。
+- [x] **预计耗时:** 20 分钟
+- [x] **实际耗时:** 15 分钟
+- [x] **验证:** `node node_modules/jest/bin/jest.js src/modules/content/content.controller.spec.ts --runInBand --verbose` 曾观察到 6/6 通过；后续重跑在当前 runtime 偶发 exit 139。
+
+### Task 2: 补充后端单元测试
+
+- [x] **文件:** `packages/wuh.site.nest/src/modules/content/content.controller.spec.ts`
+- [x] 覆盖多个 labels 输入时 controller 传递 `{ labels: { $all: [...] } }`。
+- [x] 覆盖单 label 输入仍能正常查询。
+- [x] **预计耗时:** 30 分钟
+- [x] **实际耗时:** 15 分钟
+- [x] **验证:** 先观察到 `$in` vs `$all` 失败，再观察到 6/6 通过；`pnpm --filter` 在当前环境 exit 139。
+
+## Phase 2: 前端多标签状态
+
+### Task 3: 解析和请求多个 labels
+
+- [x] **文件:** `packages/wuh.site.next/app/blog/page.tsx`
+- [x] 将 active label 状态从单值改为去重数组。
+- [x] 支持重复查询参数和逗号分隔两种 URL 输入。
+- [x] 将多 labels 传给 `contentService.getPosts.server`。
+- [x] **预计耗时:** 40 分钟
+- [x] **实际耗时:** 35 分钟
+- [x] **验证:** `node --test test/blog-filter-utils.test.mjs` 4/4 通过；`packages/wuh.site.next/node_modules/.bin/oxlint packages/wuh.site.next/app/blog` 通过。
+
+### Task 4: 多 token 和 URL 生成
+
+- [x] **文件:** `packages/wuh.site.next/app/blog/BlogListView.tsx`
+- [x] `buildBlogUrl` 支持多个 labels，并在分页链接中保留全部 labels。
+- [x] 标签菜单点击未选标签时追加筛选条件并重置页码。
+- [x] 已选标签渲染为多个 token，每个 token 可单独移除。
+- [x] 已选 token 只显示标签名，不显示 `(+count)`。
+- [x] **预计耗时:** 50 分钟
+- [x] **实际耗时:** 35 分钟
+- [x] **验证:** `node --test test/blog-filter-utils.test.mjs` 覆盖多 labels URL、追加、移除。
+
+## Phase 3: 过滤条视觉和文案
+
+### Task 5: 标签数量与入口文案
+
+- [x] **文件:** `packages/wuh.site.next/app/blog/BlogListView.tsx`
+- [x] 下拉项显示 `name(+count)`。
+- [x] 当存在已选标签时，入口显示当前 AND 查询结果数，例如 `Labels(+2)`。
+- [x] 移除 `open posts` / `filtered by` 结果提示文案。
+- [x] **预计耗时:** 25 分钟
+- [x] **实际耗时:** 15 分钟
+- [x] **验证:** `node --test test/blog-filter-utils.test.mjs` 覆盖数量文案。
+
+### Task 6: 统一主题色背景
+
+- [x] **文件:** `packages/wuh.site.next/app/blog/styles/index.ts`
+- [x] 过滤条容器、工具栏、菜单、hover、active、token 背景统一使用主题色相关 CSS 变量。
+- [x] 保持浅色/暗色主题下文字对比度和可点击区域清晰。
+- [x] **预计耗时:** 30 分钟
+- [x] **实际耗时:** 20 分钟
+- [x] **验证:** `packages/wuh.site.next/node_modules/.bin/oxlint packages/wuh.site.next/app/blog` 通过。
+
+## 验收
+
+- [x] `/blog?labels=javascript&labels=react` 只展示同时包含两个标签的 open 博客。
+- [x] 分页链接保留全部已选 labels。
+- [x] 已选 token 可以单独移除，移除最后一个 token 后回到无筛选状态。
+- [x] 标签菜单项显示 `标签名(+数量)`。
+- [x] 选择标签时入口显示当前 AND 查询结果数，例如 `Labels(+2)`。
+- [x] 过滤条背景、hover、active、token 状态与主题色保持一致。
+- [ ] `node node_modules/typescript/bin/tsc --noEmit` 当前环境 exit 139，未取得类型检查结果。

--- a/openspec/specs/blog-category-filter/spec.md
+++ b/openspec/specs/blog-category-filter/spec.md
@@ -8,11 +8,23 @@
 - **THEN** 页面跳转到包含 `labels=<label>` 的 `/blog` URL
 - **AND** 列表仅展示该 label 下 open 状态的博客文章
 
+### Requirement: 多标签 AND 分类查询
+- **GIVEN** 用户访问博客列表页
+- **WHEN** 用户选择多个 label 作为分类筛选条件
+- **THEN** 页面 URL 包含全部已选 labels 查询参数
+- **AND** 列表仅展示同时包含全部已选 labels 的 open 状态博客文章
+
 ### Requirement: 分类筛选状态可分享
 - **GIVEN** 用户访问 `/blog?labels=frontend`
 - **WHEN** 页面服务端渲染并请求博客列表数据
 - **THEN** 请求参数包含 `state=open` 和 `labels=frontend`
 - **AND** 页面展示当前筛选 token `frontend`
+
+### Requirement: 多标签筛选状态可分享
+- **GIVEN** 用户访问 `/blog?labels=javascript&labels=react`
+- **WHEN** 页面服务端渲染并请求博客列表数据
+- **THEN** 请求参数包含 `state=open` 和全部 labels
+- **AND** 页面展示当前全部筛选 token
 
 ### Requirement: 分类入口展示完整 open 标签汇总
 - **GIVEN** open 状态博客包含多个 Issue labels
@@ -21,11 +33,25 @@
 - **AND** 每个 label 包含名称和文章数量
 - **AND** closed 状态 issues 的 labels 不参与汇总
 
+### Requirement: 分类数量文案
+- **GIVEN** open 状态博客包含 labels 汇总
+- **WHEN** 用户打开博客列表页的分类过滤条
+- **THEN** 每个分类选项以 `label(+count)` 格式展示名称和文章数量
+- **AND** 外部已选 token 不展示文章数量
+- **AND** 当用户选择一个或多个标签时，分类入口展示当前 AND 查询结果数，例如 `Labels(+2)`
+- **AND** 当用户没有选择标签时，分类入口展示 `Labels`
+
 ### Requirement: 分类筛选与分页联动
 - **GIVEN** 用户处于 `/blog?labels=frontend`
 - **WHEN** 用户点击分页器进入第 2 页
 - **THEN** 目标 URL 为 `/blog?labels=frontend&page=2`
 - **AND** 当前分类筛选不会丢失
+
+### Requirement: 多标签分类筛选与分页联动
+- **GIVEN** 用户处于 `/blog?labels=javascript&labels=react`
+- **WHEN** 用户点击分页器进入第 2 页
+- **THEN** 目标 URL 保留全部已选 labels 并包含 `page=2`
+- **AND** 当前多标签筛选不会丢失
 
 ### Requirement: 切换分类重置分页
 - **GIVEN** 用户处于 `/blog?labels=frontend&page=3`
@@ -33,11 +59,20 @@
 - **THEN** 目标 URL 为 `/blog?labels=nextjs`
 - **AND** 不保留旧的 `page=3`
 
+### Requirement: 多个筛选 token 可单独移除
+- **GIVEN** 用户处于 `/blog?labels=javascript&labels=react`
+- **WHEN** 用户移除 `react` token
+- **THEN** 页面跳转到仅保留 `javascript` 的筛选 URL
+- **AND** 当最后一个 token 被移除时页面回到 `/blog`
+- **AND** 外部已选 token 只展示标签名
+
 ### Requirement: GitHub Issues 风格过滤条
 - **GIVEN** 博客列表页渲染
 - **WHEN** 用户查看标题下方区域
 - **THEN** 页面展示 GitHub Issues 风格的分类过滤条
-- **AND** 过滤条包含 `Labels` 入口、结果说明和当前筛选 token
+- **AND** 过滤条包含 `Labels` 或 `Labels(+n)` 入口和当前筛选 token
+- **AND** 过滤条背景、active、hover、token 状态与站点主题色保持一致
+- **AND** 过滤条不展示 `open posts` 或 `filtered by` 结果提示文案
 
 ---
 
@@ -46,7 +81,7 @@
 ### Requirement: 博客列表分页 URL
 - **GIVEN** 博客列表处于分类筛选状态
 - **WHEN** 分页器生成页码链接
-- **THEN** 页码链接保留当前 `labels` 查询参数
+- **THEN** 页码链接保留当前全部 `labels` 查询参数
 - **AND** 第 1 页链接省略 `page` 参数
 
 ---

--- a/openspec/specs/content-api/spec.md
+++ b/openspec/specs/content-api/spec.md
@@ -30,6 +30,14 @@
 - **WHEN** 参数经 `@Transform` 处理
 - **THEN** `labels` 被解析为 `["javascript", "typescript"]`
 
+### Requirement: Multiple labels query uses AND semantics
+多个 `labels` 查询条件使用 AND 语义过滤内容。
+
+- **GIVEN** 内容列表接口收到多个 `labels` 查询条件
+- **WHEN** 服务端构造数据库查询条件
+- **THEN** 查询条件使用数组全部匹配语义
+- **AND** 返回结果中的每篇文章都同时包含全部指定 labels
+
 ### Requirement: Post detail derives cover from first content image
 文章详情接口在缺少手动封面时，从正文 HTML 第一张图片推导封面。
 

--- a/packages/wuh.site.nest/src/modules/content/content.controller.spec.ts
+++ b/packages/wuh.site.nest/src/modules/content/content.controller.spec.ts
@@ -1,6 +1,25 @@
 import { ContentController } from './content.controller';
 
 describe('ContentController likePost', () => {
+  it('filters posts by requiring all requested labels', async () => {
+    const contentService = {
+      findAll: jest.fn().mockResolvedValue({ data: [], pagination: {} }),
+    };
+    const controller = new ContentController(contentService as any);
+
+    await controller.getPosts({
+      page: 1,
+      limit: 10,
+      state: 'open',
+      labels: ['javascript', 'react'],
+    } as any);
+
+    expect(contentService.findAll).toHaveBeenCalledWith(1, 10, {
+      labels: { $all: ['javascript', 'react'] },
+      state: 'open',
+    });
+  });
+
   it('returns open label summaries from the content service', async () => {
     const contentService = {
       getLabelSummaries: jest.fn().mockResolvedValue([

--- a/packages/wuh.site.nest/src/modules/content/content.controller.ts
+++ b/packages/wuh.site.nest/src/modules/content/content.controller.ts
@@ -74,7 +74,7 @@ export class ContentController {
     const dbQuery: Record<string, any> = {};
 
     if (labels && labels.length > 0) {
-      dbQuery.labels = { $in: labels };
+      dbQuery.labels = { $all: labels };
     }
     if (state) {
       dbQuery.state = state;

--- a/packages/wuh.site.next/app/blog/BlogListView.tsx
+++ b/packages/wuh.site.next/app/blog/BlogListView.tsx
@@ -10,6 +10,7 @@ import BackHomeLink from '@/app/components/BackHomeLink'
 import type { ContentLabelSummary, PostListItem } from '@wuh.site/shared-contracts'
 import { buildPostUrl } from '../lib/slug'
 import { formatShortDate } from '../lib/date'
+import { buildBlogUrl, formatFilterOptionLabel, getFilterSummaryLabel, toggleLabel } from './blog-filter-utils'
 import * as S from './styles'
 
 const TAG_DISPLAY_LIMIT = 3
@@ -17,7 +18,7 @@ const TAG_DISPLAY_LIMIT = 3
 type Props = {
   posts: PostListItem[]
   pagination: { currentPage: number; lastPage: number; total?: number }
-  activeLabel?: string
+  activeLabels: string[]
   availableLabels: ContentLabelSummary[]
 }
 
@@ -35,21 +36,13 @@ const groupByYear = (posts: PostListItem[]) => {
   return Array.from(map.entries()).sort((a, b) => b[0] - a[0])
 }
 
-const buildBlogUrl = (page: number, label?: string) => {
-  const params = new URLSearchParams()
-  if (label) params.set('labels', label)
-  if (page > 1) params.set('page', String(page))
-  const query = params.toString()
-  return query ? `/blog?${query}` : '/blog'
-}
-
 /**
  * 博客列表视图，按年份分组展示博客文章，支持分页。
  */
-export default function BlogListView({ posts, pagination, activeLabel, availableLabels }: Props) {
+export default function BlogListView({ posts, pagination, activeLabels, availableLabels }: Props) {
   const yearGroups = useMemo(() => groupByYear(posts), [posts])
-  const resultTotal = pagination.total ?? posts.length
   const hasLabels = availableLabels.length > 0
+  const filteredTotal = pagination.total ?? posts.length
 
   return (
     <S.Root>
@@ -67,17 +60,16 @@ export default function BlogListView({ posts, pagination, activeLabel, available
         <S.FilterBar aria-label="博客分类过滤">
           <S.FilterToolbar>
             <S.FilterMenu>
-              <S.FilterSummary>Labels</S.FilterSummary>
+              <S.FilterSummary>{getFilterSummaryLabel(availableLabels, activeLabels, filteredTotal)}</S.FilterSummary>
               <S.FilterMenuList>
                 {hasLabels ? (
                   availableLabels.map(label => (
                     <S.FilterOption
                       key={label.name}
-                      href={buildBlogUrl(1, label.name)}
-                      $active={label.name === activeLabel}
+                      href={buildBlogUrl(1, toggleLabel(activeLabels, label.name))}
+                      $active={activeLabels.includes(label.name)}
                     >
-                      <span>{label.name}</span>
-                      <S.FilterCount>{label.count}</S.FilterCount>
+                      <span>{formatFilterOptionLabel(label)}</span>
                     </S.FilterOption>
                   ))
                 ) : (
@@ -85,15 +77,16 @@ export default function BlogListView({ posts, pagination, activeLabel, available
                 )}
               </S.FilterMenuList>
             </S.FilterMenu>
-            <S.FilterSummaryText>
-              {activeLabel ? `${resultTotal} open posts filtered by` : `${resultTotal} open posts`}
-            </S.FilterSummaryText>
-            {activeLabel && (
-              <S.FilterToken href="/blog" aria-label={`清除 ${activeLabel} 分类筛选`}>
-                {activeLabel}
+            {activeLabels.map((label) => (
+              <S.FilterToken
+                key={label}
+                href={buildBlogUrl(1, activeLabels.filter((item) => item !== label))}
+                aria-label={`清除 ${label} 分类筛选`}
+              >
+                {label}
                 <span aria-hidden="true">×</span>
               </S.FilterToken>
-            )}
+            ))}
           </S.FilterToolbar>
         </S.FilterBar>
 
@@ -131,7 +124,7 @@ export default function BlogListView({ posts, pagination, activeLabel, available
         <Pagination
           currentPage={pagination.currentPage}
           totalPages={pagination.lastPage}
-          getPageUrl={(page) => buildBlogUrl(page, activeLabel)}
+          getPageUrl={(page) => buildBlogUrl(page, activeLabels)}
         />
       </S.Main>
     </S.Root>

--- a/packages/wuh.site.next/app/blog/blog-filter-utils.ts
+++ b/packages/wuh.site.next/app/blog/blog-filter-utils.ts
@@ -1,0 +1,41 @@
+import type { ContentLabelSummary } from '@wuh.site/shared-contracts'
+
+export const toLabelParams = (value: string | string[] | undefined): string[] => {
+  const values = Array.isArray(value) ? value : value ? [value] : []
+  const labels = values.flatMap((item) => item.split(',')).map((item) => item.trim()).filter(Boolean)
+  return Array.from(new Set(labels))
+}
+
+export const buildBlogUrl = (page: number, labels: string[] = []): string => {
+  const params = new URLSearchParams()
+  labels.forEach((label) => params.append('labels', label))
+  if (page > 1) params.set('page', String(page))
+  const query = params.toString()
+  return query ? `/blog?${query}` : '/blog'
+}
+
+export const toggleLabel = (activeLabels: string[], label: string): string[] => {
+  return activeLabels.includes(label)
+    ? activeLabels.filter((item) => item !== label)
+    : [...activeLabels, label]
+}
+
+export const formatFilterOptionLabel = (label: ContentLabelSummary): string => {
+  return `${label.name}(+${label.count})`
+}
+
+export const getFilterSummaryLabel = (
+  availableLabels: ContentLabelSummary[],
+  activeLabels: string[],
+  filteredTotal?: number,
+): string => {
+  if (activeLabels.length === 0) return 'Labels'
+
+  if (Number.isFinite(filteredTotal)) {
+    return `Labels(+${filteredTotal})`
+  }
+
+  const activeCount = availableLabels.find((label) => label.name === activeLabels[0])?.count ?? 0
+
+  return activeCount > 0 ? `Labels(+${activeCount})` : 'Labels'
+}

--- a/packages/wuh.site.next/app/blog/page.tsx
+++ b/packages/wuh.site.next/app/blog/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { contentService } from '@wuh.site/shared-contracts/endpoints'
 import type { ContentItem, ContentLabelSummary, PostListItem } from '@wuh.site/shared-contracts'
 import BlogListView from './BlogListView'
+import { toLabelParams } from './blog-filter-utils'
 
 const SITE_URL = 'https://wuh.site'
 
@@ -47,15 +48,9 @@ const toPageNumber = (value: string | string[] | undefined) => {
   return Number.isNaN(page) || page < 1 ? 1 : page
 }
 
-const toLabelParam = (value: string | string[] | undefined) => {
-  const raw = Array.isArray(value) ? value[0] : value
-  const label = raw?.trim()
-  return label ? label : undefined
-}
-
-async function getIssues(page: number, label?: string) {
+async function getIssues(page: number, labels: string[]) {
   const { data, error } = await contentService.getPosts.server({
-    query: { page: String(page), limit: String(PER_PAGE), state: 'open', labels: label },
+    query: { page: String(page), limit: String(PER_PAGE), state: 'open', labels },
     revalidate: 600,
   })
 
@@ -96,9 +91,9 @@ export default async function Page({
 }) {
   const resolvedSearchParams = await searchParams
   const currentPage = toPageNumber(resolvedSearchParams?.page)
-  const activeLabel = toLabelParam(resolvedSearchParams?.labels)
+  const activeLabels = toLabelParams(resolvedSearchParams?.labels)
   const [{ posts, pagination }, availableLabels] = await Promise.all([
-    getIssues(currentPage, activeLabel),
+    getIssues(currentPage, activeLabels),
     getLabels(),
   ])
 
@@ -106,7 +101,7 @@ export default async function Page({
     <BlogListView
       posts={posts}
       pagination={pagination}
-      activeLabel={activeLabel}
+      activeLabels={activeLabels}
       availableLabels={availableLabels}
     />
   )

--- a/packages/wuh.site.next/app/blog/styles/index.ts
+++ b/packages/wuh.site.next/app/blog/styles/index.ts
@@ -45,9 +45,9 @@ export const FilterBar = styled.section`
   position: relative;
   z-index: 20;
   width: 100%;
-  border: 1px solid color-mix(in oklab, var(--text-muted) 28%, transparent);
+  border: 1px solid color-mix(in oklab, var(--accent-color) 32%, var(--background-100, #fff));
   border-radius: 8px;
-  background: var(--background-100, #fff);
+  background: color-mix(in oklab, var(--accent-color) 8%, var(--background-100, #fff));
   overflow: visible;
 `
 
@@ -60,16 +60,16 @@ export const FilterToolbar = styled.div`
   min-height: 46px;
   padding: 10px 12px;
   border-radius: 8px;
-  background: color-mix(in oklab, var(--text-muted) 8%, var(--background-100, #fff));
+  background: color-mix(in oklab, var(--accent-color) 10%, var(--background-100, #fff));
 `
 
 export const FilterMenu = styled.details`
   position: relative;
 
   &[open] > summary {
-    border-color: color-mix(in oklab, var(--accent-color) 55%, transparent);
+    border-color: color-mix(in oklab, var(--accent-color) 64%, var(--background-100, #fff));
     color: var(--primary-color);
-    background: color-mix(in oklab, var(--accent-color) 8%, var(--background-100, #fff));
+    background: color-mix(in oklab, var(--accent-color) 18%, var(--background-100, #fff));
   }
 `
 
@@ -79,9 +79,9 @@ export const FilterSummary = styled.summary`
   gap: 6px;
   min-height: 30px;
   padding: 0 10px;
-  border: 1px solid color-mix(in oklab, var(--text-muted) 30%, transparent);
+  border: 1px solid color-mix(in oklab, var(--accent-color) 34%, var(--background-100, #fff));
   border-radius: 6px;
-  background: var(--background-100, #fff);
+  background: color-mix(in oklab, var(--accent-color) 6%, var(--background-100, #fff));
   color: var(--text-secondary);
   font-size: var(--font-size-sm);
   cursor: pointer;
@@ -100,9 +100,9 @@ export const FilterSummary = styled.summary`
   }
 
   &:hover {
-    border-color: color-mix(in oklab, var(--accent-color) 45%, transparent);
+    border-color: color-mix(in oklab, var(--accent-color) 58%, var(--background-100, #fff));
     color: var(--primary-color);
-    background: color-mix(in oklab, var(--accent-color) 6%, var(--background-100, #fff));
+    background: color-mix(in oklab, var(--accent-color) 14%, var(--background-100, #fff));
   }
 `
 
@@ -116,9 +116,9 @@ export const FilterMenuList = styled.div`
   max-height: 320px;
   flex-direction: column;
   overflow-y: auto;
-  border: 1px solid color-mix(in oklab, var(--text-muted) 26%, transparent);
+  border: 1px solid color-mix(in oklab, var(--accent-color) 32%, var(--background-100, #fff));
   border-radius: 8px;
-  background: var(--background-100, #fff);
+  background: color-mix(in oklab, var(--accent-color) 6%, var(--background-100, #fff));
   box-shadow: 0 16px 40px color-mix(in oklab, #000 16%, transparent);
   padding: 6px;
 `
@@ -132,30 +132,20 @@ export const FilterOption = styled(Link)<{ $active: boolean }>`
   padding: 0 10px;
   border-radius: 6px;
   color: ${({ $active }) => ($active ? 'var(--primary-color)' : 'var(--text-secondary)')};
-  background: ${({ $active }) => ($active ? 'color-mix(in oklab, var(--accent-color) 10%, var(--background-100, #fff))' : 'var(--background-100, #fff)')};
+  background: ${({ $active }) => ($active ? 'color-mix(in oklab, var(--accent-color) 20%, var(--background-100, #fff))' : 'transparent')};
   font-size: var(--font-size-sm);
   text-decoration: none;
   transition: background-color var(--transition-fast) ease, color var(--transition-fast) ease;
 
   &:hover {
     color: var(--primary-color);
-    background: color-mix(in oklab, var(--accent-color) 8%, var(--background-100, #fff));
+    background: color-mix(in oklab, var(--accent-color) 16%, var(--background-100, #fff));
     text-decoration: none;
   }
 `
 
-export const FilterCount = styled.span`
-  color: var(--text-muted);
-  font-size: var(--font-size-xs);
-`
-
 export const FilterEmpty = styled.span`
   padding: 8px 10px;
-  color: var(--text-muted);
-  font-size: var(--font-size-sm);
-`
-
-export const FilterSummaryText = styled.span`
   color: var(--text-muted);
   font-size: var(--font-size-sm);
 `
@@ -166,17 +156,17 @@ export const FilterToken = styled(Link)`
   gap: 6px;
   min-height: 26px;
   padding: 0 8px;
-  border: 1px solid color-mix(in oklab, var(--accent-color) 42%, transparent);
+  border: 1px solid color-mix(in oklab, var(--accent-color) 46%, var(--background-100, #fff));
   border-radius: 6px;
   color: var(--primary-color);
-  background: color-mix(in oklab, var(--accent-color) 12%, transparent);
+  background: color-mix(in oklab, var(--accent-color) 18%, var(--background-100, #fff));
   font-size: var(--font-size-xs);
   text-decoration: none;
   transition: border-color var(--transition-fast) ease, background-color var(--transition-fast) ease;
 
   &:hover {
-    border-color: color-mix(in oklab, var(--accent-color) 70%, transparent);
-    background: color-mix(in oklab, var(--accent-color) 18%, transparent);
+    border-color: color-mix(in oklab, var(--accent-color) 70%, var(--background-100, #fff));
+    background: color-mix(in oklab, var(--accent-color) 26%, var(--background-100, #fff));
     text-decoration: none;
   }
 `

--- a/packages/wuh.site.next/test/blog-filter-utils.test.mjs
+++ b/packages/wuh.site.next/test/blog-filter-utils.test.mjs
@@ -1,0 +1,40 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  buildBlogUrl,
+  formatFilterOptionLabel,
+  getFilterSummaryLabel,
+  toLabelParams,
+  toggleLabel,
+} from '../app/blog/blog-filter-utils.ts'
+
+test('normalizes repeated and comma-separated labels', () => {
+  assert.deepEqual(toLabelParams(['javascript, react', 'nextjs', 'react']), [
+    'javascript',
+    'react',
+    'nextjs',
+  ])
+})
+
+test('builds blog urls with all active labels and optional page', () => {
+  assert.equal(buildBlogUrl(2, ['javascript', 'react']), '/blog?labels=javascript&labels=react&page=2')
+  assert.equal(buildBlogUrl(1, []), '/blog')
+})
+
+test('toggles labels while preserving selection order', () => {
+  assert.deepEqual(toggleLabel(['javascript'], 'react'), ['javascript', 'react'])
+  assert.deepEqual(toggleLabel(['javascript', 'react'], 'javascript'), ['react'])
+})
+
+test('formats label counts and filtered result summary total', () => {
+  const labels = [
+    { name: 'javascript', count: 8 },
+    { name: 'vue', count: 3 },
+    { name: 'react', count: 5 },
+  ]
+
+  assert.equal(formatFilterOptionLabel({ name: 'javascript', count: 8 }), 'javascript(+8)')
+  assert.equal(getFilterSummaryLabel(labels, ['javascript'], 8), 'Labels(+8)')
+  assert.equal(getFilterSummaryLabel(labels, ['javascript', 'vue'], 2), 'Labels(+2)')
+  assert.equal(getFilterSummaryLabel(labels, [], 16), 'Labels')
+})


### PR DESCRIPTION
## Summary

- 支持 /blog 多 labels AND 查询
- 标签菜单显示 label(+count)，外部 token 只显示标签名
- Labels(+n) 使用当前 AND 查询结果数
- 归档 OpenSpec 并同步主 specs/index

Closes #186