### PR TITLE
Feat: guestbook composer as tg-style floating bar (#194)

### DIFF
--- a/packages/wuh.site.next/app/about/components/GuestbookBarrageDialog.tsx
+++ b/packages/wuh.site.next/app/about/components/GuestbookBarrageDialog.tsx
@@ -11,12 +11,10 @@ import {
   ChatRow,
   ChatStatus,
   Composer,
-  ComposerActions,
-  ComposerFields,
+  ComposerBadge,
   ComposerInput,
-  ComposerTextArea,
-  GuestbookBody,
-  GuestbookPanel,
+  ComposerNicknameInput,
+  ComposerSend,
   GuestbookStage,
   GuestbookTrigger,
   GuestbookTriggerAvatar,
@@ -88,7 +86,9 @@ export default function GuestbookBarrageDialog() {
   const [listError, setListError] = useState<string | null>(null)
   const [localMessages, setLocalMessages] = useState<GuestbookMessage[]>([])
   const [submitting, setSubmitting] = useState(false)
+  const [editingNickname, setEditingNickname] = useState(false)
   const feedRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
 
   const clamped = useMemo(() => clampGuestbookContent(content), [content])
   const trimmedNickname = nickname.trim()
@@ -133,7 +133,7 @@ export default function GuestbookBarrageDialog() {
 
   useEffect(() => {
     feedRef.current?.scrollTo({ top: feedRef.current.scrollHeight, behavior: 'smooth' })
-  }, [chatMessages.length, open])
+  }, [chatMessages.length])
 
   useEffect(() => {
     if (!open) return
@@ -178,9 +178,15 @@ export default function GuestbookBarrageDialog() {
     }
   }, [footprint, open])
 
+  useEffect(() => {
+    if (open && inputRef.current) {
+      inputRef.current.focus()
+    }
+  }, [open])
+
   const handleChange = (value: string) => {
-    const next = clampGuestbookContent(value)
-    setContent(next.value)
+    if (value.length > MAX_LENGTH) return
+    setContent(value)
   }
 
   const handleNicknameChange = (value: string) => {
@@ -201,15 +207,14 @@ export default function GuestbookBarrageDialog() {
     if (!canSubmit || submitting) return
 
     const nextMessages = createGuestbookMessage(localMessages, {
-      nickname,
-      content,
+      nickname: trimmedNickname,
+      content: clamped.value.trim(),
       footprint,
     }) as GuestbookMessage[]
     const currentMessage = nextMessages[nextMessages.length - 1]
     if (!currentMessage) return
 
     setLocalMessages(nextMessages)
-    handleNicknameChange(nickname)
     setContent('')
     setSubmitting(true)
 
@@ -259,6 +264,14 @@ export default function GuestbookBarrageDialog() {
     }
   }
 
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault()
+      const form = (event.target as HTMLInputElement).closest('form')
+      form?.requestSubmit()
+    }
+  }
+
   return (
     <>
       <GuestbookTrigger type='button' onClick={() => setOpen(true)}>
@@ -268,11 +281,11 @@ export default function GuestbookBarrageDialog() {
         </GuestbookTriggerAvatars>
         <GuestbookTriggerCopy>
           <GuestbookTriggerLabel>Guestbook</GuestbookTriggerLabel>
-          <GuestbookTriggerTitle>潘江陆海，各撒云尔~</GuestbookTriggerTitle>
+          <GuestbookTriggerTitle>给我留一句话</GuestbookTriggerTitle>
           <GuestbookTriggerPreview>最近看到的想法、建议或者招呼，都可以放在这里。</GuestbookTriggerPreview>
         </GuestbookTriggerCopy>
         <GuestbookTriggerCta>
-          <span>见字如面</span>
+          <span>进入</span>
           <IconArrowRight />
         </GuestbookTriggerCta>
       </GuestbookTrigger>
@@ -285,73 +298,73 @@ export default function GuestbookBarrageDialog() {
         height='min(720px, calc(100vh - 80px))'
       >
         <GuestbookWrapper>
-          <GuestbookBody>
-            <GuestbookPanel>
-              <GuestbookStage>
-                <ChatFeed ref={feedRef}>
-                  {loadingMessages && (
-                    <div>留言加载中...</div>
-                  )}
-                  {listError && (
-                    <div>留言加载失败</div>
-                  )}
-                  {!loadingMessages && !listError && chatMessages.map((item) => (
-                    <ChatRow key={item.id} $mine={Boolean(item.mine)}>
-                      <ChatAvatar aria-hidden='true'>{getAvatarText(item.nickname)}</ChatAvatar>
-                      <ChatBubble $mine={Boolean(item.mine)}>
-                        <ChatMessageMeta>
-                          <span>{item.nickname}</span>
-                          <time>{item.time}</time>
-                        </ChatMessageMeta>
-                        <p>{item.content}</p>
-                        {item.status === 'sending' && <ChatStatus>发送中...</ChatStatus>}
-                        {item.status === 'sent' && <ChatStatus>已发送</ChatStatus>}
-                        {item.status === 'failed' && (
-                          <ChatStatus $tone='error'>{item.error || '发送失败'}</ChatStatus>
-                        )}
-                      </ChatBubble>
-                    </ChatRow>
-                  ))}
-                  {!loadingMessages && !listError && chatMessages.length === 0 && (
-                    <div style={{ color: 'var(--text-muted)', padding: '24px 0', textAlign: 'center', fontSize: '0.82rem' }}>
-                      还没有留言，来发第一条吧。
-                    </div>
-                  )}
-                </ChatFeed>
-              </GuestbookStage>
-
-              <Composer onSubmit={handleSubmit}>
-                <ComposerFields>
-                  <ComposerInput
-                    value={nickname}
-                    placeholder='你的昵称'
-                    maxLength={20}
-                    onChange={(event) => handleNicknameChange(event.target.value)}
-                  />
-                  {nickname.trim().length >= MIN_NICKNAME_LENGTH && <div />}
-                  <ComposerTextArea
-                    value={content}
-                    maxLength={MAX_LENGTH}
-                    rows={1}
-                    placeholder='在群里说点什么...'
-                    onChange={(event) => handleChange(event.target.value)}
-                  />
-                </ComposerFields>
-                <ComposerActions>
-                  <button type='submit' disabled={!canSubmit || submitting}>
-                    <IconArrowRight />
-                    <span>发送</span>
-                  </button>
-                </ComposerActions>
-              </Composer>
-
-              {failedCount > 0 && (
-                <div style={{ textAlign: 'center', fontSize: '0.72rem', color: 'var(--primary-color)' }}>
-                  {failedCount} 条发送失败
+          <GuestbookStage>
+            <ChatFeed ref={feedRef}>
+              {loadingMessages && (
+                <div>留言加载中...</div>
+              )}
+              {listError && (
+                <div>留言加载失败</div>
+              )}
+              {!loadingMessages && !listError && chatMessages.map((item) => (
+                <ChatRow key={item.id} $mine={Boolean(item.mine)}>
+                  <ChatAvatar aria-hidden='true'>{getAvatarText(item.nickname)}</ChatAvatar>
+                  <ChatBubble $mine={Boolean(item.mine)}>
+                    <ChatMessageMeta>
+                      <span>{item.nickname}</span>
+                      <time>{item.time}</time>
+                    </ChatMessageMeta>
+                    <p>{item.content}</p>
+                    {item.status === 'sending' && <ChatStatus>发送中...</ChatStatus>}
+                    {item.status === 'sent' && <ChatStatus>已发送</ChatStatus>}
+                    {item.status === 'failed' && (
+                      <ChatStatus $tone='error'>{item.error || '发送失败'}</ChatStatus>
+                    )}
+                  </ChatBubble>
+                </ChatRow>
+              ))}
+              {!loadingMessages && !listError && chatMessages.length === 0 && (
+                <div style={{ color: 'var(--text-muted)', padding: '24px 0', textAlign: 'center', fontSize: '0.82rem' }}>
+                  还没有留言，来发第一条吧。
                 </div>
               )}
-            </GuestbookPanel>
-          </GuestbookBody>
+            </ChatFeed>
+          </GuestbookStage>
+
+          <Composer onSubmit={handleSubmit}>
+            <ComposerBadge type='button' onClick={() => setEditingNickname(!editingNickname)} title='点击修改昵称'>
+              {getAvatarText(trimmedNickname)}
+            </ComposerBadge>
+            {editingNickname ? (
+              <ComposerNicknameInput
+                value={nickname}
+                placeholder='你的昵称'
+                maxLength={20}
+                onChange={(event) => handleNicknameChange(event.target.value)}
+                onBlur={() => setEditingNickname(false)}
+                onKeyDown={(event) => { if (event.key === 'Enter' && !event.shiftKey) { event.preventDefault(); setEditingNickname(false); }}}
+                autoFocus
+              />
+            ) : (
+              <ComposerInput
+                ref={inputRef}
+                value={content}
+                placeholder={trimmedNickname ? `作为 ${trimmedNickname}，说点什么...` : '说点什么...'}
+                onChange={(event) => handleChange(event.target.value)}
+                onKeyDown={handleKeyDown}
+                maxLength={MAX_LENGTH}
+              />
+            )}
+            <ComposerSend type='submit' disabled={!canSubmit || submitting}>
+              <IconArrowRight />
+            </ComposerSend>
+          </Composer>
+
+          {failedCount > 0 && (
+            <div style={{ textAlign: 'center', fontSize: '0.72rem', color: 'var(--primary-color)' }}>
+              {failedCount} 条发送失败
+            </div>
+          )}
         </GuestbookWrapper>
       </Dialog>
     </>

--- a/packages/wuh.site.next/app/about/components/GuestbookBarrageDialog.tsx
+++ b/packages/wuh.site.next/app/about/components/GuestbookBarrageDialog.tsx
@@ -12,14 +12,12 @@ import {
   ChatStatus,
   Composer,
   ComposerActions,
-  ComposerMeta,
+  ComposerFields,
+  ComposerInput,
   ComposerTextArea,
   GuestbookBody,
-  GuestbookHeader,
   GuestbookPanel,
   GuestbookStage,
-  GuestbookSubtitle,
-  GuestbookTitle,
   GuestbookTrigger,
   GuestbookTriggerAvatar,
   GuestbookTriggerAvatars,
@@ -29,7 +27,6 @@ import {
   GuestbookTriggerPreview,
   GuestbookTriggerTitle,
   GuestbookWrapper,
-  LayoutBadge,
 } from './guestbook-barrage.styles'
 import {
   clampGuestbookContent,
@@ -130,7 +127,6 @@ export default function GuestbookBarrageDialog() {
         setFootprint(nextFootprint)
       }
     } catch {
-      // localStorage can be unavailable in hardened browsing modes.
       setFootprint(createFootprint())
     }
   }, [])
@@ -289,29 +285,17 @@ export default function GuestbookBarrageDialog() {
         height='min(720px, calc(100vh - 80px))'
       >
         <GuestbookWrapper>
-          <GuestbookHeader>
-            <div>
-              <GuestbookTitle>留言板</GuestbookTitle>
-              <GuestbookSubtitle>像群聊一样留下一句话，点击发送后会立即提交。</GuestbookSubtitle>
-            </div>
-            <LayoutBadge>
-              {submitting
-                ? '发送中'
-                : loadingMessages
-                  ? '加载中'
-                  : listError
-                    ? '加载失败'
-                    : failedCount
-                      ? `${failedCount} 条失败`
-                      : '群聊模式'}
-            </LayoutBadge>
-          </GuestbookHeader>
-
           <GuestbookBody>
             <GuestbookPanel>
               <GuestbookStage>
                 <ChatFeed ref={feedRef}>
-                  {chatMessages.map((item) => (
+                  {loadingMessages && (
+                    <div>留言加载中...</div>
+                  )}
+                  {listError && (
+                    <div>留言加载失败</div>
+                  )}
+                  {!loadingMessages && !listError && chatMessages.map((item) => (
                     <ChatRow key={item.id} $mine={Boolean(item.mine)}>
                       <ChatAvatar aria-hidden='true'>{getAvatarText(item.nickname)}</ChatAvatar>
                       <ChatBubble $mine={Boolean(item.mine)}>
@@ -328,40 +312,44 @@ export default function GuestbookBarrageDialog() {
                       </ChatBubble>
                     </ChatRow>
                   ))}
+                  {!loadingMessages && !listError && chatMessages.length === 0 && (
+                    <div style={{ color: 'var(--text-muted)', padding: '24px 0', textAlign: 'center', fontSize: '0.82rem' }}>
+                      还没有留言，来发第一条吧。
+                    </div>
+                  )}
                 </ChatFeed>
               </GuestbookStage>
 
               <Composer onSubmit={handleSubmit}>
-                <input
-                  value={nickname}
-                  placeholder='你的昵称'
-                  maxLength={20}
-                  onChange={(event) => handleNicknameChange(event.target.value)}
-                />
-                <ComposerTextArea
-                  value={content}
-                  maxLength={MAX_LENGTH}
-                  rows={2}
-                  placeholder='在群里说点什么...'
-                  onChange={(event) => handleChange(event.target.value)}
-                />
-                <ComposerMeta $overLimit={clamped.remaining === 0 && clamped.length > 0}>
-                  <span>
-                    {trimmedNickname.length < MIN_NICKNAME_LENGTH
-                      ? '昵称至少 2 个字符'
-                      : trimmedContent.length < MIN_CONTENT_LENGTH
-                        ? '内容至少 5 个字符'
-                        : `当前昵称：${trimmedNickname}`}
-                  </span>
-                  <span>{clamped.length} / {MAX_LENGTH}</span>
-                </ComposerMeta>
+                <ComposerFields>
+                  <ComposerInput
+                    value={nickname}
+                    placeholder='你的昵称'
+                    maxLength={20}
+                    onChange={(event) => handleNicknameChange(event.target.value)}
+                  />
+                  {nickname.trim().length >= MIN_NICKNAME_LENGTH && <div />}
+                  <ComposerTextArea
+                    value={content}
+                    maxLength={MAX_LENGTH}
+                    rows={1}
+                    placeholder='在群里说点什么...'
+                    onChange={(event) => handleChange(event.target.value)}
+                  />
+                </ComposerFields>
                 <ComposerActions>
                   <button type='submit' disabled={!canSubmit || submitting}>
                     <IconArrowRight />
-                    发送
+                    <span>发送</span>
                   </button>
                 </ComposerActions>
               </Composer>
+
+              {failedCount > 0 && (
+                <div style={{ textAlign: 'center', fontSize: '0.72rem', color: 'var(--primary-color)' }}>
+                  {failedCount} 条发送失败
+                </div>
+              )}
             </GuestbookPanel>
           </GuestbookBody>
         </GuestbookWrapper>

--- a/packages/wuh.site.next/app/about/components/guestbook-barrage.styles.ts
+++ b/packages/wuh.site.next/app/about/components/guestbook-barrage.styles.ts
@@ -1,5 +1,7 @@
 import styled from '@wuh.site/components/styled'
 
+/* ====== Trigger ====== */
+
 export const GuestbookTrigger = styled.button`
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
@@ -123,6 +125,8 @@ export const GuestbookTriggerCta = styled.span`
   }
 `
 
+/* ====== Dialog Inner ====== */
+
 export const GuestbookWrapper = styled.div`
   --guestbook-border: color-mix(in oklab, var(--normal-300) 34%, transparent);
   --guestbook-border-strong: color-mix(in oklab, var(--normal-300) 45%, transparent);
@@ -145,6 +149,7 @@ export const GuestbookWrapper = styled.div`
   --guestbook-composer-bg: color-mix(in oklab, var(--background-100) 96%, var(--primary-color) 4%);
   --guestbook-control-bg: var(--background-100);
   --guestbook-shadow: 0 8px 18px rgba(0, 0, 0, 0.04);
+  --guestbook-bar-bg: color-mix(in oklab, var(--background-200) 92%, var(--background-100));
 
   display: flex;
   flex-direction: column;
@@ -173,48 +178,13 @@ export const GuestbookWrapper = styled.div`
     --guestbook-composer-bg: color-mix(in oklab, var(--background-200) 72%, var(--background-100));
     --guestbook-control-bg: color-mix(in oklab, var(--background-200) 86%, var(--background-100));
     --guestbook-shadow: 0 12px 20px rgba(0, 0, 0, 0.16);
+    --guestbook-bar-bg: color-mix(in oklab, var(--background-100) 86%, var(--background-200) 14%);
   }
-`
-
-export const GuestbookHeader = styled.header`
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 12px 0 16px;
-  border-bottom: 1px solid var(--guestbook-border);
-`
-
-export const GuestbookTitle = styled.h3`
-  margin: 0;
-  font-size: 0.98rem;
-`
-
-export const GuestbookSubtitle = styled.p`
-  margin: 6px 0 0;
-  color: var(--text-secondary);
-  font-size: 0.78rem;
-  line-height: 1.6;
-`
-
-export const LayoutBadge = styled.span`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 32px;
-  padding: 0 12px;
-  border-radius: 999px;
-  background: color-mix(in oklab, var(--primary-color) 10%, transparent);
-  color: var(--primary-color);
-  font-size: 0.72rem;
-  font-weight: 600;
-  white-space: nowrap;
 `
 
 export const GuestbookBody = styled.div`
   flex: 1;
   min-height: 0;
-  padding-top: 16px;
 `
 
 export const GuestbookPanel = styled.section`
@@ -222,7 +192,7 @@ export const GuestbookPanel = styled.section`
   flex-direction: column;
   min-height: 0;
   height: 100%;
-  gap: 12px;
+  gap: 8px;
 `
 
 export const GuestbookStage = styled.div`
@@ -230,7 +200,7 @@ export const GuestbookStage = styled.div`
   flex: 1;
   min-height: 320px;
   overflow: hidden;
-  border-radius: 14px;
+  border-radius: 16px;
   border: 1px solid var(--guestbook-border);
   background:
     var(--guestbook-stage-highlight),
@@ -330,47 +300,52 @@ export const ChatStatus = styled.span<{ $tone?: 'error' }>`
   font-size: 0.7rem;
 `
 
+/* ====== Composer Bar ====== */
+
 export const Composer = styled.form`
   display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 12px;
-  border-radius: 14px;
+  align-items: flex-end;
+  gap: 10px;
+  padding: 12px 16px;
+  border-radius: 16px;
   border: 1px solid var(--guestbook-border);
-  background: var(--guestbook-composer-bg);
+  background: var(--guestbook-bar-bg);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+`
 
-  input {
-    width: 100%;
-    min-height: 38px;
-    border: 1px solid var(--guestbook-border-strong);
-    border-radius: 10px;
-    padding: 8px 11px;
-    background: var(--guestbook-control-bg);
-    color: var(--text-primary);
-    font: inherit;
-    font-size: 0.82rem;
-    line-height: 1.5;
-    outline: none;
-  }
+export const ComposerFields = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+`
 
-  input::placeholder {
-    color: var(--text-secondary);
-  }
+export const ComposerInput = styled.input`
+  min-height: 30px;
+  border: none;
+  padding: 0;
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  outline: none;
 
-  input:focus {
-    border-color: color-mix(in oklab, var(--primary-color) 36%, var(--normal-300) 64%);
-    box-shadow: 0 0 0 3px color-mix(in oklab, var(--primary-color) 12%, transparent);
+  &::placeholder {
+    color: var(--text-muted);
   }
 `
 
 export const ComposerTextArea = styled.textarea`
   width: 100%;
-  min-height: 38px;
+  min-height: 22px;
+  max-height: 80px;
   resize: none;
-  border: 1px solid var(--guestbook-border-strong);
-  border-radius: 10px;
-  padding: 8px 11px;
-  background: var(--guestbook-control-bg);
+  border: none;
+  padding: 0;
+  background: transparent;
   color: var(--text-primary);
   font: inherit;
   font-size: 0.82rem;
@@ -378,52 +353,53 @@ export const ComposerTextArea = styled.textarea`
   outline: none;
 
   &::placeholder {
-    color: var(--text-secondary);
+    color: var(--text-muted);
   }
 
   &:focus {
-    border-color: color-mix(in oklab, var(--primary-color) 36%, var(--normal-300) 64%);
-    box-shadow: 0 0 0 3px color-mix(in oklab, var(--primary-color) 12%, transparent);
+    outline: none;
   }
-`
-
-export const ComposerMeta = styled.div<{ $overLimit: boolean }>`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  color: ${({ $overLimit }) => ($overLimit ? 'var(--primary-color)' : 'var(--text-secondary)')};
-  font-size: 0.72rem;
 `
 
 export const ComposerActions = styled.div`
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  gap: 10px;
+  flex-shrink: 0;
 
   button {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: 8px;
-    min-height: 36px;
-    padding: 0 12px;
-    border-radius: 999px;
-    border: 1px solid var(--guestbook-border-strong);
-    background: var(--guestbook-control-bg);
-    color: var(--text-primary);
+    gap: 0;
+    min-width: 40px;
+    min-height: 40px;
+    padding: 0;
+    border: 2px solid color-mix(in oklab, var(--primary-color) 20%, transparent);
+    border-radius: 50%;
+    background: color-mix(in oklab, var(--primary-color) 12%, var(--background-100));
+    color: var(--primary-color);
     cursor: pointer;
     font-size: 0.82rem;
+    font-weight: 600;
+    transition: all 0.2s ease;
+
+    &:hover:not(:disabled) {
+      background: color-mix(in oklab, var(--primary-color) 20%, var(--background-100));
+      border-color: color-mix(in oklab, var(--primary-color) 40%, transparent);
+    }
   }
 
   button:disabled {
     cursor: not-allowed;
-    opacity: 0.5;
+    opacity: 0.4;
   }
 
   svg {
-    width: 16px;
-    height: 16px;
+    width: 18px;
+    height: 18px;
+  }
+
+  span {
+    display: none;
   }
 `

--- a/packages/wuh.site.next/app/about/components/guestbook-barrage.styles.ts
+++ b/packages/wuh.site.next/app/about/components/guestbook-barrage.styles.ts
@@ -146,10 +146,7 @@ export const GuestbookWrapper = styled.div`
   --guestbook-bubble-other-bg: color-mix(in oklab, var(--background-100) 94%, var(--background-200));
   --guestbook-bubble-mine-border: color-mix(in oklab, var(--primary-color) 24%, transparent);
   --guestbook-bubble-other-border: color-mix(in oklab, var(--normal-300) 36%, transparent);
-  --guestbook-composer-bg: color-mix(in oklab, var(--background-100) 96%, var(--primary-color) 4%);
-  --guestbook-control-bg: var(--background-100);
   --guestbook-shadow: 0 8px 18px rgba(0, 0, 0, 0.04);
-  --guestbook-bar-bg: color-mix(in oklab, var(--background-200) 92%, var(--background-100));
 
   display: flex;
   flex-direction: column;
@@ -175,10 +172,7 @@ export const GuestbookWrapper = styled.div`
     --guestbook-bubble-other-bg: color-mix(in oklab, var(--background-200) 78%, var(--background-100));
     --guestbook-bubble-mine-border: color-mix(in oklab, var(--primary-color) 36%, transparent);
     --guestbook-bubble-other-border: color-mix(in oklab, var(--normal-500) 42%, transparent);
-    --guestbook-composer-bg: color-mix(in oklab, var(--background-200) 72%, var(--background-100));
-    --guestbook-control-bg: color-mix(in oklab, var(--background-200) 86%, var(--background-100));
     --guestbook-shadow: 0 12px 20px rgba(0, 0, 0, 0.16);
-    --guestbook-bar-bg: color-mix(in oklab, var(--background-100) 86%, var(--background-200) 14%);
   }
 `
 
@@ -192,7 +186,6 @@ export const GuestbookPanel = styled.section`
   flex-direction: column;
   min-height: 0;
   height: 100%;
-  gap: 8px;
 `
 
 export const GuestbookStage = styled.div`
@@ -200,7 +193,7 @@ export const GuestbookStage = styled.div`
   flex: 1;
   min-height: 320px;
   overflow: hidden;
-  border-radius: 16px;
+  border-radius: 16px 16px 12px 12px;
   border: 1px solid var(--guestbook-border);
   background:
     var(--guestbook-stage-highlight),
@@ -217,11 +210,11 @@ export const ChatFeed = styled.div`
   flex-direction: column;
   gap: 12px;
   overflow: auto;
-  padding: 18px;
+  padding: 18px 18px 80px;
   scroll-behavior: smooth;
 
   @media (max-width: 640px) {
-    padding: 14px 12px;
+    padding: 14px 12px 76px;
   }
 `
 
@@ -300,106 +293,128 @@ export const ChatStatus = styled.span<{ $tone?: 'error' }>`
   font-size: 0.7rem;
 `
 
-/* ====== Composer Bar ====== */
+/* ====== Floating Composer Bar ====== */
 
 export const Composer = styled.form`
+  position: relative;
   display: flex;
-  align-items: flex-end;
-  gap: 10px;
-  padding: 12px 16px;
-  border-radius: 16px;
-  border: 1px solid var(--guestbook-border);
-  background: var(--guestbook-bar-bg);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-`
+  align-items: center;
+  gap: 8px;
+  margin: -22px 8px 8px;
+  padding: 10px 10px 10px 16px;
+  border-radius: 14px;
+  border: 1px solid color-mix(in oklab, var(--normal-300) 26%, transparent);
+  background: color-mix(in oklab, var(--background-100) 94%, var(--background-200) 6%);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  box-shadow:
+    0 4px 12px rgba(0, 0, 0, 0.06),
+    0 0 0 1px var(--background-100);
+  z-index: 2;
 
-export const ComposerFields = styled.div`
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  min-width: 0;
-`
+  &:focus-within {
+    border-color: color-mix(in oklab, var(--primary-color) 28%, var(--normal-300) 72%);
+  }
 
-export const ComposerInput = styled.input`
-  min-height: 30px;
-  border: none;
-  padding: 0;
-  background: transparent;
-  color: var(--text-secondary);
-  font: inherit;
-  font-size: 0.78rem;
-  line-height: 1.5;
-  outline: none;
-
-  &::placeholder {
-    color: var(--text-muted);
+  [data-color-scheme="dark"] & {
+    background: color-mix(in oklab, var(--background-100) 88%, var(--background-200) 12%);
+    box-shadow:
+      0 4px 16px rgba(0, 0, 0, 0.24),
+      0 0 0 1px color-mix(in oklab, var(--background-100) 80%, transparent);
   }
 `
 
-export const ComposerTextArea = styled.textarea`
-  width: 100%;
-  min-height: 22px;
-  max-height: 80px;
-  resize: none;
+export const ComposerInput = styled.input`
+  flex: 1;
+  min-height: 40px;
   border: none;
   padding: 0;
   background: transparent;
   color: var(--text-primary);
   font: inherit;
-  font-size: 0.82rem;
+  font-size: 0.86rem;
   line-height: 1.5;
   outline: none;
 
   &::placeholder {
     color: var(--text-muted);
   }
-
-  &:focus {
-    outline: none;
-  }
 `
 
-export const ComposerActions = styled.div`
-  display: flex;
+export const ComposerSend = styled.button`
+  display: inline-flex;
   align-items: center;
+  justify-content: center;
+  min-width: 40px;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: var(--primary-color);
+  color: var(--background-100);
+  cursor: pointer;
   flex-shrink: 0;
+  transition: all 0.2s ease;
+  line-height: 0;
 
-  button {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0;
-    min-width: 40px;
-    min-height: 40px;
-    padding: 0;
-    border: 2px solid color-mix(in oklab, var(--primary-color) 20%, transparent);
-    border-radius: 50%;
-    background: color-mix(in oklab, var(--primary-color) 12%, var(--background-100));
-    color: var(--primary-color);
-    cursor: pointer;
-    font-size: 0.82rem;
-    font-weight: 600;
-    transition: all 0.2s ease;
-
-    &:hover:not(:disabled) {
-      background: color-mix(in oklab, var(--primary-color) 20%, var(--background-100));
-      border-color: color-mix(in oklab, var(--primary-color) 40%, transparent);
-    }
+  &:hover:not(:disabled) {
+    background: color-mix(in oklab, var(--primary-color) 82%, black);
+    transform: scale(1.04);
   }
 
-  button:disabled {
+  &:active:not(:disabled) {
+    transform: scale(0.94);
+  }
+
+  &:disabled {
     cursor: not-allowed;
-    opacity: 0.4;
+    opacity: 0.3;
   }
 
   svg {
-    width: 18px;
-    height: 18px;
+    width: 20px;
+    height: 20px;
   }
+`
 
-  span {
-    display: none;
+export const ComposerBadge = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  min-width: 32px;
+  height: 32px;
+  padding: 0 4px;
+  border: 1px solid var(--guestbook-border);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: border-color 0.2s ease;
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 600;
+
+  &:hover {
+    border-color: color-mix(in oklab, var(--primary-color) 30%, var(--normal-300) 70%);
+  }
+`
+
+export const ComposerNicknameInput = styled.input`
+  flex: 1;
+  min-height: 40px;
+  border: none;
+  padding: 0;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 0.86rem;
+  line-height: 1.5;
+  outline: none;
+
+  &::placeholder {
+    color: var(--text-muted);
   }
 `


### PR DESCRIPTION
留言板输入区改为 Telegram 风格浮动条：

1. **输入区浮动** — margin 负值嵌入聊天区，阴影 + blur 呈现悬浮效果
2. **单行输入 + Enter 发送** — 输入框占满宽度，按 Enter 直接发送
3. **圆形发送按钮** — 主题色填充，集成在输入条最右侧
4. **昵称快捷编辑** — 左侧展示首字母圆徽，点击切换为内联昵称编辑

Closes #194