### PR TITLE
fix: 修复刷新页面时主题切换导致的闪烁问题

### DIFF
--- a/packages/components/themes/cssVariableProvider.tsx
+++ b/packages/components/themes/cssVariableProvider.tsx
@@ -211,12 +211,6 @@ export const CssVariableStyles = createGlobalStyle`
     --font-serif: Georgia, 'Songti SC', 'STSong', serif;
   }
 
-  @media (prefers-color-scheme: dark) {
-    html {
-      color-scheme: dark;
-    }
-  }
-
   html[data-no-transition] *,
   html[data-no-transition] *::before,
   html[data-no-transition] *::after {

--- a/packages/wuh.site.next/app/layout.tsx
+++ b/packages/wuh.site.next/app/layout.tsx
@@ -46,15 +46,25 @@ export default function RootLayout({
           dangerouslySetInnerHTML={{
             __html: `
 (function() {
+  // Step 1: disable all CSS transitions before touching data attrs
+  document.documentElement.setAttribute('data-no-transition', '');
+  // Force reflow so the transition:none rule is applied
+  void document.documentElement.offsetHeight;
+
+  // Step 2: set theme color scheme
   var scheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   document.documentElement.dataset.colorScheme = scheme;
+
+  // Step 3: restore persisted theme family
   try {
     var stored = window.localStorage.getItem('wuh.site.theme');
     if (stored === 'wine' || stored === 'plain') {
       document.documentElement.dataset.themeFamily = stored;
     }
   } catch (_) {}
-  document.documentElement.dataset.noTransition = 'true';
+
+  // Step 4: re-enable transitions now that data attrs are settled
+  document.documentElement.removeAttribute('data-no-transition');
 })();
           `.trim(),
           }}


### PR DESCRIPTION
## 问题

刷新页面时出现颜色闪烁（light↔dark 主题切换时）。Closes #199

## 修改

| 文件 | 说明 |
|---|---|
| `layout.tsx` | 用 `setAttribute` 替代 dataset API；调整执行顺序为先禁用过渡 → 强制 reflow → 设置主题 → 恢复过渡 |
| `cssVariableProvider.tsx` | 移除与 viewport colorScheme 冲突的 `@media (prefers-color-scheme: dark)` 规则 |

## 验证

- [x] TypeScript 编译通过