### PR TITLE
fix: 使用 @/ 路径别名替代相对路径 (#201)

### DIFF
--- a/packages/wuh.site.next/app/components/AppProviders.tsx
+++ b/packages/wuh.site.next/app/components/AppProviders.tsx
@@ -7,7 +7,7 @@ import { useRef } from 'react'
 import { useEventListener, useRequest } from 'ahooks'
 import type { ReactNode } from 'react'
 import Footer from '@wuh.site/components/layout/footer'
-import { VisitStatsReporter } from '../../components/visit-stats/visit-stats-reporter'
+import { VisitStatsReporter } from '@/components/visit-stats/visit-stats-reporter'
 import dynamic from 'next/dynamic'
 import { AudioPlayerProvider } from '@wuh.site/components/audio-player/provider'
 


### PR DESCRIPTION
## 修复内容

将 VisitStatsReporter 的导入从相对路径改为路径别名。
- 之前: `../../components/visit-stats/visit-stats-reporter`
- 修正: `@/components/visit-stats/visit-stats-reporter`

符合项目规范: `@/*` 映射到 next 项目根目录。

Closes #201