### PR TITLE
fix: 访问量统计字色与 footer 其他文字一致 (#207)

### DIFF
--- a/openspec/changes/archive/2026-07-12-B-fix-stats-text-color/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-12-B-fix-stats-text-color/.openspec.yaml
@@ -1,0 +1,16 @@
+project: x.wuh.site
+change: 2026-07-12-B-fix-stats-text-color
+date: 2026-07-12
+type: B
+status: archived
+issue: https://github.com/stack-wuh/x.wuh.site/issues/207
+
+domain:
+  name: 修复访问量字色
+  keywords:
+    - 访问量
+    - footer
+    - 字色
+    - visit-stats
+    - 视觉
+  description: 去掉 StatsText 的 color: var(--text-muted)，继承 Footer 的 var(--text-color)

--- a/packages/components/layout/site-stats.tsx
+++ b/packages/components/layout/site-stats.tsx
@@ -1,10 +1,9 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import styled from 'styled-components';
+import styled from '@wuh.site/components/styled';
 
 const StatsText = styled.div`
-  color: var(--text-muted);
   font-size: var(--font-size-sm);
 `;
 


### PR DESCRIPTION
## 修复

`StatsText` 去掉 `color: var(--text-muted)` 覆盖，继承父级 Footer 的 `var(--text-color)`。同时改用 `@wuh.site/components/styled` 导入。

Closes #207