### PR TITLE
fix: 首页微信读书模块按最近阅读时间排序 (#209)

### DIFF
--- a/openspec/specs/weread-shelf-order/spec.md
+++ b/openspec/specs/weread-shelf-order/spec.md
@@ -2,26 +2,24 @@
 
 ## ADDED
 
-### Requirement: 微信读书页面保持书架顺序
-- **GIVEN** 后端已从 WeRead `/shelf/sync` 同步 `books[]` 书籍列表
-- **WHEN** 用户访问 `/weread` 页面并请求任意分页
-- **THEN** 页面应按 WeRead `books[]` 原始列表顺序展示书籍
-- **AND** 分页切换不应按最近阅读时间重新排序
-
 ### Requirement: 首页展示在读前 6 本
 - **GIVEN** WeRead 书架中存在至少 6 本 `finishReading=0` 的书籍
 - **WHEN** 用户访问首页微信读书模块
-- **THEN** 模块应展示 WeRead 书架顺序中前 6 本在读书籍
+- **THEN** 模块应展示最近阅读时间前 6 本在读书籍
 - **AND** `finishReading=1` 的已读完书籍不应占用首页 6 个展示名额
-
-### Requirement: 同步持久化书架位置
-- **GIVEN** WeRead `/shelf/sync` 返回 `books[]` 数组
-- **WHEN** 后端执行微信读书同步
-- **THEN** 每本书应保存其在 `books[]` 中的顺序位置
-- **AND** 后续查询应使用该顺序位置作为默认排序依据
 
 ### Requirement: 微信读书分页查询
 - **GIVEN** 客户端请求微信读书书籍分页接口
 - **WHEN** 请求携带 `page` 和 `limit`
-- **THEN** 接口应在书架顺序基础上分页返回结果
+- **THEN** 接口应按最近阅读时间降序分页返回结果
 - **AND** 当请求携带 `finishReading=0` 或 `finishReading=1` 时，应先按阅读完成状态过滤再计算分页总数
+
+## MODIFIED
+
+### Requirement: 默认排序改为最近阅读时间
+- **GIVEN** 后端查询 WeRead 书籍
+- **WHEN** 未指定排序参数
+- **THEN** 默认按 `readUpdateTime` 降序排列
+- **AND** 以 `_id` 降序作为二级排序
+- **AND** 移除 `shelfIndex` 排序依赖
+  - 移除原因: `shelfIndex` 仅记录同步 API 返回的数组下标，不代表用户实际阅读顺序

--- a/packages/wuh.site.nest/src/modules/weread/weread.service.ts
+++ b/packages/wuh.site.nest/src/modules/weread/weread.service.ts
@@ -73,7 +73,7 @@ export class WereadService {
     const [data, total] = await Promise.all([
       this.wereadBookModel
         .find(filter)
-        .sort({ shelfIndex: 1, readUpdateTime: -1 })
+        .sort({ readUpdateTime: -1 })
         .skip((page - 1) * limit)
         .limit(limit)
         .lean()


### PR DESCRIPTION
## 修复

后端 `weread.service.ts` 排序从 `{ shelfIndex: 1, readUpdateTime: -1 }` 改为 `{ readUpdateTime: -1 }`。

`shelfIndex` 仅记录同步 API 返回的数组下标，不代表实际阅读节奏。按 `readUpdateTime` 降序后，首页 `limit: 6, finishReading: 0` 取到的就是最近在读的 6 本。

同时更新 `weread-shelf-order` spec 移除 `shelfIndex` 排序依赖。

Closes #209