### PR TITLE
fix: 博客详情页封面图展示错误 + 封面与首图去重 (#211)

### DIFF
--- a/packages/wuh.site.nest/src/modules/content/content-cover.util.ts
+++ b/packages/wuh.site.nest/src/modules/content/content-cover.util.ts
@@ -14,3 +14,19 @@ export function extractFirstImageUrl(bodyHtml?: string | null, body?: string | n
   const markdownMatch = body?.match(MARKDOWN_IMAGE_RE);
   return normalizeImageUrl(markdownMatch?.[1] ?? markdownMatch?.[2]);
 }
+
+/**
+ * 提取第一张图片 URL，并从 bodyHtml 中移除对应的 <img> 标签。
+ * 用于封面图推导：当封面来自文章第一张图时，避免重复展示。
+ */
+export function extractFirstImageAndClean(
+  bodyHtml?: string | null,
+  body?: string | null,
+): { url: string | undefined; cleanHtml: string | null | undefined } {
+  const url = extractFirstImageUrl(bodyHtml, body);
+  if (!url || !bodyHtml) {
+    return { url, cleanHtml: bodyHtml };
+  }
+  const cleanHtml = bodyHtml.replace(HTML_IMAGE_RE, '');
+  return { url, cleanHtml: cleanHtml || null };
+}

--- a/packages/wuh.site.nest/src/modules/content/content.controller.ts
+++ b/packages/wuh.site.nest/src/modules/content/content.controller.ts
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { ContentService } from './content.service';
 import { QueryContentDto } from './dto/content.dto';
 import { Request, Response } from 'express';
-import { extractFirstImageUrl } from './content-cover.util';
+import { extractFirstImageAndClean } from './content-cover.util';
 
 const ANON_COOKIE_NAME = 'anonId';
 const ANON_COOKIE_MAX_AGE = 1000 * 60 * 60 * 24 * 365;
@@ -45,11 +45,16 @@ type PostWithCoverSource = {
 };
 
 function withDerivedCover<T extends PostWithCoverSource>(post: T): T {
-  const cover = post.metadata?.cover || extractFirstImageUrl(post.bodyHtml, post.body);
+  if (post.metadata?.cover) {
+    return post;
+  }
+
+  const { url: cover, cleanHtml } = extractFirstImageAndClean(post.bodyHtml, post.body);
   if (!cover) return post;
 
   return {
     ...post,
+    bodyHtml: cleanHtml,
     metadata: {
       ...(post.metadata ?? {}),
       cover,

--- a/packages/wuh.site.next/app/post/components/PostCover.tsx
+++ b/packages/wuh.site.next/app/post/components/PostCover.tsx
@@ -13,7 +13,7 @@ export default function PostCover({ src, alt }: Props) {
 
   return (
     <CoverImage>
-      <Image src={src} alt={alt} />
+      <Image src={src} alt={alt} fill />
     </CoverImage>
   )
 }


### PR DESCRIPTION
## Bug

封面图展示异常 — `PostCover` 使用 `Image` 组件时缺少 `fill` prop，`next/image` 无法正确填充容器。

## 优化

`withDerivedCover` 从文章首图推导封面时，自动从 `bodyHtml` 移除该图片，避免正文重复展示。

## 改动

| 文件 | 变更 |
|------|------|
| PostCover.tsx | 增加 `fill` prop |
| content-cover.util.ts | 新增 `extractFirstImageAndClean` |
| content.controller.ts | `withDerivedCover` 使用新函数，推导封面时清理 bodyHtml |

Closes #211