### PR TITLE
fix: 博客详情页所有博客链接使用主题色 (#213)

### DIFF
--- a/packages/wuh.site.next/app/post/styles/post-toolbar.ts
+++ b/packages/wuh.site.next/app/post/styles/post-toolbar.ts
@@ -135,9 +135,9 @@ export const Toolbar = styled.div`
     padding: 0 10px;
     font-size: 0.8rem;
     font-weight: 500;
-    color: var(--normal-400);
+    color: var(--primary-color);
     text-decoration: none;
-    opacity: 0.45;
+    opacity: 0.7;
     transition: opacity 0.2s ease, color 0.2s ease;
     z-index: 2;
   }


### PR DESCRIPTION
## 改动

`.toolbar-back` 默认色从 `var(--normal-400)` 改为 `var(--primary-color)`，opacity 从 0.45 提升到 0.7。

Closes #213