### PR TITLE
feat: 博客详情页评论功能（GitHub Issue 双向集成）(#215)

### DIFF
--- a/packages/shared-contracts/src/index.ts
+++ b/packages/shared-contracts/src/index.ts
@@ -92,6 +92,7 @@ export interface CreateAnonymousCommentDto {
   content: string;
   footprint?: string;
   page?: string;
+  issueNumber?: number;
 }
 
 export interface QueryCommentDto {

--- a/packages/wuh.site.nest/src/modules/comment/comment.controller.ts
+++ b/packages/wuh.site.nest/src/modules/comment/comment.controller.ts
@@ -2,11 +2,14 @@ import {
   Controller,
   Get,
   Post,
+  Patch,
   Body,
+  Param,
   Query,
   Req,
   UseGuards,
   BadRequestException,
+  NotFoundException,
 } from '@nestjs/common';
 import { ThrottlerGuard } from '@nestjs/throttler';
 import { ApiTags, ApiOperation, ApiQuery, ApiResponse } from '@nestjs/swagger';
@@ -54,16 +57,35 @@ export class CommentController {
       throw new BadRequestException('nickname and content are required');
     }
 
+    const issueNumber = createCommentDto.issueNumber ?? GUESTBOOK_ISSUE_NUMBER;
+
     const commentData: any = {
       ...createCommentDto,
       body: createCommentDto.content,
       clientIp: req.ip || req.socket.remoteAddress,
       userAgent: req.headers['user-agent'],
       externalId: uuidv4(),
-      issueId: GUESTBOOK_ISSUE_NUMBER,
-      issueNumber: GUESTBOOK_ISSUE_NUMBER,
-      repo: 'guestbook',
+      issueId: issueNumber,
+      issueNumber: issueNumber,
+      repo: issueNumber === GUESTBOOK_ISSUE_NUMBER ? 'guestbook' : 'blog',
     };
+
+    // Blog comments start as pending, guestbook auto-approved
+    if (issueNumber !== GUESTBOOK_ISSUE_NUMBER) {
+      commentData.status = 'pending';
+    }
     return this.commentService.create(commentData);
   }
+  @Patch(':id/approve')
+  @ApiOperation({ summary: 'Approve and post comment to GitHub Issue' })
+  @ApiResponse({ status: 200, description: 'Comment approved and posted to GitHub' })
+  @ApiResponse({ status: 404, description: 'Comment not found' })
+  async approveComment(@Param('id') id: string) {
+    const result = await this.commentService.approveAndPostToGitHub(id);
+    if (!result) {
+      throw new NotFoundException('Comment not found');
+    }
+    return result;
+  }
 }
+

--- a/packages/wuh.site.nest/src/modules/comment/comment.module.ts
+++ b/packages/wuh.site.nest/src/modules/comment/comment.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { MongooseModule } from '@nestjs/mongoose';
 import { Comment, CommentSchema } from './schemas/comment.schema';
 import { CommentService } from './comment.service';
@@ -6,6 +7,7 @@ import { CommentController } from './comment.controller';
 
 @Module({
   imports: [
+    ConfigModule,
     MongooseModule.forFeature([
       { name: Comment.name, schema: CommentSchema },
     ]),

--- a/packages/wuh.site.nest/src/modules/comment/comment.service.ts
+++ b/packages/wuh.site.nest/src/modules/comment/comment.service.ts
@@ -1,4 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Octokit } from '@octokit/rest';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { Comment, CommentDocument } from './schemas/comment.schema';
@@ -14,7 +16,19 @@ export class CommentService {
 
   constructor(
     @InjectModel(Comment.name) private commentModel: Model<CommentDocument>,
-  ) {}
+    private configService: ConfigService,
+  ) {
+    const token = this.configService.get<string>('GITHUB_PERSONAL_TOKEN');
+    if (token) {
+      this.octokit = new Octokit({ auth: token });
+      this.repoOwner = this.configService.get<string>('CONTENT_REPO_OWNER') || '';
+      this.repoName = this.configService.get<string>('CONTENT_REPO_NAME') || '';
+    }
+  }
+
+  private octokit?: Octokit;
+  private repoOwner = '';
+  private repoName = '';
 
   async create(createCommentDto: CreateAnonymousCommentDto): Promise<CommentDocument> {
     try {
@@ -93,6 +107,47 @@ export class CommentService {
 
   async delete(id: string): Promise<CommentDocument | null> {
     return this.commentModel.findByIdAndDelete(id).exec();
+  }
+
+  async approveAndPostToGitHub(commentId: string): Promise<CommentDocument | null> {
+    const comment = await this.commentModel.findById(commentId).exec();
+    if (!comment) return null;
+
+    if (!this.octokit) {
+      this.logger.error('GitHub token not configured, cannot post comment');
+      return this.commentModel
+        .findByIdAndUpdate(commentId, { status: 'approved' }, { new: true })
+        .exec();
+    }
+
+    try {
+      const body = comment.nickname
+        ? `**${comment.nickname}** 评论：
+
+${comment.body}`
+        : comment.body;
+
+      const { data } = await this.octokit.issues.createComment({
+        owner: this.repoOwner,
+        repo: this.repoName,
+        issue_number: comment.issueNumber,
+        body,
+      });
+
+      return this.commentModel
+        .findByIdAndUpdate(
+          commentId,
+          {
+            externalId: String(data.id),
+            status: 'approved',
+          },
+          { new: true },
+        )
+        .exec();
+    } catch (error) {
+      this.logger.error(`Failed to post comment to GitHub: ${error.message}`);
+      throw error;
+    }
   }
 
   private generateAvatarUrl(seed: string): string {

--- a/packages/wuh.site.nest/src/modules/comment/dto/comment.dto.ts
+++ b/packages/wuh.site.nest/src/modules/comment/dto/comment.dto.ts
@@ -28,6 +28,12 @@ export class CreateAnonymousCommentDto implements ICreateAnonymousCommentDto {
   @IsString()
   @IsOptional()
   page?: string;
+
+  @ApiPropertyOptional({ description: 'GitHub issue number (blog post)' })
+  @Type(() => Number)
+  @IsNumber()
+  @IsOptional()
+  issueNumber?: number;
 }
 
 export class QueryCommentDto implements IQueryCommentDto {

--- a/packages/wuh.site.next/app/post/PostView.tsx
+++ b/packages/wuh.site.next/app/post/PostView.tsx
@@ -12,13 +12,14 @@ import { useHeadingObserver } from './hooks/useHeadingObserver'
 import PostHeader from './components/PostHeader'
 import PostCover from './components/PostCover'
 import PostToolbar from './components/PostToolbar'
+import PostComments from './components/PostComments'
 import FloatingActions from './components/FloatingActions'
 import { openSharePopup, openWechatShareWindow } from '../share-utils'
 
 import { buildPostUrl } from '@/app/lib/slug'
 import {
   ArticleCard,
-  CommentPlaceholder,
+  PostComments,
   Container,
   ContentGrid,
   MainColumn,

--- a/packages/wuh.site.next/app/post/components/PostComments.tsx
+++ b/packages/wuh.site.next/app/post/components/PostComments.tsx
@@ -1,0 +1,411 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import styled from '@wuh.site/components/styled'
+import Button from '@wuh.site/components/button'
+import { IconGithub, IconTag } from '@wuh.site/components/icons'
+import message from '@wuh.site/components/message'
+
+type Comment = {
+  _id?: string
+  externalId?: string | number
+  issueNumber: number
+  body: string
+  bodyHtml?: string
+  user?: {
+    login: string
+    avatarUrl: string
+    url: string
+  } | null
+  nickname?: string
+  avatarUrl?: string
+  status?: 'pending' | 'approved' | 'rejected'
+  createdAtGitHub?: string
+  createdAt?: string
+}
+
+function formatTime(dateStr?: string): string {
+  if (!dateStr) return ''
+  const date = new Date(dateStr)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffMin = Math.floor(diffMs / 60000)
+
+  if (diffMin < 1) return '刚刚'
+  if (diffMin < 60) return `${diffMin} 分钟前`
+
+  const diffHour = Math.floor(diffMin / 60)
+  if (diffHour < 24) return `${diffHour} 小时前`
+
+  const diffDay = Math.floor(diffHour / 24)
+  if (diffDay < 7) return `${diffDay} 天前`
+
+  return date.toLocaleDateString('zh-CN', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+function getAvatarText(name: string): string {
+  return name.trim().charAt(0).toUpperCase() || '?'
+}
+
+function getAvatarUrl(comment: Comment): string | null {
+  if (comment.user?.avatarUrl) return comment.user.avatarUrl
+  if (comment.avatarUrl) return comment.avatarUrl
+  return null
+}
+
+function getDisplayName(comment: Comment): string {
+  if (comment.user?.login) return comment.user.login
+  return comment.nickname || '匿名'
+}
+
+function isGithubComment(comment: Comment): boolean {
+  return Boolean(comment.user?.login)
+}
+
+// Styles
+const Wrapper = styled.div`
+  margin-top: var(--space-xl);
+`
+
+const CommentsHeader = styled.h3`
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 var(--space-md);
+`
+
+const CommentItem = styled.div<{ $isGithub?: boolean }>`
+  display: flex;
+  gap: 12px;
+  padding: 14px 0;
+  border-bottom: 1px solid color-mix(in oklab, var(--normal-300) 20%, transparent);
+
+  &:last-child {
+    border-bottom: none;
+  }
+`
+
+const CommentAvatar = styled.div`
+  width: 36px;
+  height: 36px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  overflow: hidden;
+  background: color-mix(in oklab, var(--primary-color) 14%, var(--background-100));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--primary-color);
+  border: 1px solid color-mix(in oklab, var(--primary-color) 18%, transparent);
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+`
+
+const CommentBody = styled.div`
+  flex: 1;
+  min-width: 0;
+`
+
+const CommentMeta = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+  font-size: var(--font-size-sm);
+`
+
+const CommentAuthor = styled.span`
+  font-weight: 600;
+  color: var(--text-primary);
+`
+
+const CommentTime = styled.time`
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+`
+
+const CommentSource = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 11px;
+  color: var(--text-muted);
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: color-mix(in oklab, var(--normal-300) 12%, transparent);
+`
+
+const CommentText = styled.div`
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  line-height: 1.6;
+  word-break: break-word;
+`
+
+const CommentStatusBadge = styled.span<{ $status: string }>`
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 11px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  color: ${({ $status }) =>
+    $status === 'approved' ? 'var(--success-color)' :
+    $status === 'pending' ? 'var(--warning-color)' :
+    'var(--danger-color)'};
+  background: ${({ $status }) =>
+    $status === 'approved' ? 'color-mix(in oklab, var(--success-color) 10%, transparent)' :
+    $status === 'pending' ? 'color-mix(in oklab, var(--warning-color) 10%, transparent)' :
+    'color-mix(in oklab, var(--danger-color) 10%, transparent)'};
+`
+
+const InputArea = styled.div`
+  margin-top: var(--space-lg);
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px solid color-mix(in oklab, var(--normal-300) 24%, transparent);
+  background: var(--background-100);
+`
+
+const NicknameRow = styled.div`
+  margin-bottom: 10px;
+`
+
+const NicknameInput = styled.input`
+  width: 100%;
+  max-width: 200px;
+  padding: 8px 12px;
+  border: 1px solid color-mix(in oklab, var(--normal-300) 36%, transparent);
+  border-radius: 8px;
+  background: var(--background-200);
+  color: var(--text-primary);
+  font-size: var(--font-size-sm);
+  outline: none;
+
+  &:focus {
+    border-color: color-mix(in oklab, var(--primary-color) 36%, transparent);
+  }
+
+  &::placeholder {
+    color: var(--text-muted);
+  }
+`
+
+const ContentTextarea = styled.textarea`
+  width: 100%;
+  min-height: 80px;
+  padding: 10px 12px;
+  border: 1px solid color-mix(in oklab, var(--normal-300) 36%, transparent);
+  border-radius: 8px;
+  background: var(--background-200);
+  color: var(--text-primary);
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+  resize: vertical;
+  outline: none;
+  box-sizing: border-box;
+  font-family: inherit;
+
+  &:focus {
+    border-color: color-mix(in oklab, var(--primary-color) 36%, transparent);
+  }
+
+  &::placeholder {
+    color: var(--text-muted);
+  }
+`
+
+const SubmitRow = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 10px;
+`
+
+const EmptyState = styled.div`
+  text-align: center;
+  padding: 32px 0;
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+`
+
+const LoadingState = styled.div`
+  text-align: center;
+  padding: 24px 0;
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+`
+
+const NICKNAME_STORAGE_KEY = 'wuh.site.comment.nickname'
+
+type Props = {
+  issueNumber: number
+}
+
+export default function PostComments({ issueNumber }: Props) {
+  const [comments, setComments] = useState<Comment[]>([])
+  const [loading, setLoading] = useState(true)
+  const [nickname, setNickname] = useState('')
+  const [content, setContent] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const inputRef = useRef<HTMLTextAreaElement>(null)
+
+  const fetchComments = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await fetch(`/api/comments?issueNumber=${issueNumber}&limit=50`, { cache: 'no-store' })
+      const data = await res.json()
+      const list = data.data || data || []
+      setComments(list.filter((c: Comment) => c.status !== 'rejected'))
+    } catch {
+      // Silent fail
+    } finally {
+      setLoading(false)
+    }
+  }, [issueNumber])
+
+  useEffect(() => {
+    fetchComments()
+    try {
+      const saved = window.localStorage.getItem(NICKNAME_STORAGE_KEY)
+      if (saved) setNickname(saved)
+    } catch { /* noop */ }
+  }, [fetchComments])
+
+  const trimmedNickname = nickname.trim()
+  const trimmedContent = content.trim()
+  const canSubmit = trimmedNickname.length >= 2 && trimmedContent.length >= 5
+
+  const handleSubmit = useCallback(async () => {
+    if (!canSubmit || submitting) return
+    setSubmitting(true)
+
+    try {
+      const res = await fetch('/api/comments', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          nickname: trimmedNickname,
+          content: trimmedContent,
+          issueNumber,
+        }),
+      })
+      const data = await res.json()
+
+      if (!res.ok) {
+        throw new Error(data.message || '评论提交失败')
+      }
+
+      // Save nickname and add optimistic comment
+      try { window.localStorage.setItem(NICKNAME_STORAGE_KEY, trimmedNickname) } catch { /* noop */ }
+
+      const optimistic: Comment = {
+        _id: data._id || `optimistic-${Date.now()}`,
+        issueNumber,
+        body: trimmedContent,
+        nickname: trimmedNickname,
+        avatarUrl: `https://i.pravatar.cc/150?u=${encodeURIComponent(trimmedNickname)}`,
+        status: 'pending',
+        createdAt: new Date().toISOString(),
+      }
+      setComments((prev) => [...prev, optimistic])
+      setContent('')
+      message.success('评论已提交，等待审核')
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : '评论提交失败'
+      message.error(msg)
+    } finally {
+      setSubmitting(false)
+    }
+  }, [canSubmit, submitting, trimmedNickname, trimmedContent, issueNumber])
+
+  const approveCount = comments.filter((c) => c.status === 'approved').length
+  const pendingCount = comments.filter((c) => c.status === 'pending').length
+  const totalCount = comments.length
+
+  return (
+    <Wrapper>
+      <CommentsHeader>
+        评论{totalCount > 0 ? ` (${totalCount})` : ''}
+      </CommentsHeader>
+
+      {loading ? (
+        <LoadingState>加载中...</LoadingState>
+      ) : comments.length === 0 ? (
+        <EmptyState>
+          还没有评论，来发表第一条吧。
+        </EmptyState>
+      ) : (
+        comments.map((comment) => (
+          <CommentItem key={comment._id || comment.externalId} $isGithub={isGithubComment(comment)}>
+            <CommentAvatar>
+              {getAvatarUrl(comment) ? (
+                <img src={getAvatarUrl(comment)!} alt={getDisplayName(comment)} />
+              ) : (
+                getAvatarText(getDisplayName(comment))
+              )}
+            </CommentAvatar>
+            <CommentBody>
+              <CommentMeta>
+                <CommentAuthor>{getDisplayName(comment)}</CommentAuthor>
+                <CommentTime>{formatTime(comment.createdAtGitHub || comment.createdAt)}</CommentTime>
+                {isGithubComment(comment) ? (
+                  <CommentSource><IconGithub /> GitHub</CommentSource>
+                ) : (
+                  <CommentSource><IconTag /> 网站</CommentSource>
+                )}
+                {comment.status === 'pending' && (
+                  <CommentStatusBadge $status='pending'>审核中</CommentStatusBadge>
+                )}
+                {comment.status === 'approved' && (
+                  <CommentStatusBadge $status='approved'>已同步到 Issue</CommentStatusBadge>
+                )}
+              </CommentMeta>
+              <CommentText>
+                {comment.bodyHtml ? (
+                  <span dangerouslySetInnerHTML={{ __html: comment.bodyHtml }} />
+                ) : (
+                  comment.body
+                )}
+              </CommentText>
+            </CommentBody>
+          </CommentItem>
+        ))
+      )}
+
+      <InputArea>
+        <NicknameRow>
+          <NicknameInput
+            value={nickname}
+            onChange={(e) => setNickname(e.target.value)}
+            placeholder='你的昵称'
+            maxLength={20}
+          />
+        </NicknameRow>
+        <ContentTextarea
+          ref={inputRef}
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          placeholder='说点什么...'
+          maxLength={500}
+        />
+        <SubmitRow>
+          <Button
+            variant='filled'
+            color='primary'
+            size='small'
+            disabled={!canSubmit || submitting}
+            onClick={handleSubmit}
+          >
+            {submitting ? '提交中...' : '发表评论'}
+          </Button>
+        </SubmitRow>
+      </InputArea>
+    </Wrapper>
+  )
+}


### PR DESCRIPTION
## 实现内容

### 后端
- `CreateAnonymousCommentDto` 增加 `issueNumber` 字段
- POST 自动识别博客评论 → `status: pending`
- 新增 `PATCH :id/approve` 端点 → 审核后发到 GitHub Issue → 更新 externalId
- 下次 sync 时按 externalId 自动匹配，无重复

### 前端
- `PostComments` 组件：评论区列表 + 昵称/内容输入 + 提交
- 区分 GitHub 用户评论和匿名评论（来源标记）
- 待审核/已同步状态徽标
- 替换 PostView 中的 CommentPlaceholder

Closes #215