### PR TITLE
fix: 评论功能边界修复 — 重复审批 + 错误处理 (#217)

### DIFF
--- a/packages/wuh.site.nest/src/modules/comment/comment.service.ts
+++ b/packages/wuh.site.nest/src/modules/comment/comment.service.ts
@@ -112,6 +112,7 @@ export class CommentService {
   async approveAndPostToGitHub(commentId: string): Promise<CommentDocument | null> {
     const comment = await this.commentModel.findById(commentId).exec();
     if (!comment) return null;
+    if (comment.status === 'approved') return comment;
 
     if (!this.octokit) {
       this.logger.error('GitHub token not configured, cannot post comment');

--- a/packages/wuh.site.next/app/post/components/PostComments.tsx
+++ b/packages/wuh.site.next/app/post/components/PostComments.tsx
@@ -250,6 +250,7 @@ type Props = {
 export default function PostComments({ issueNumber }: Props) {
   const [comments, setComments] = useState<Comment[]>([])
   const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
   const [nickname, setNickname] = useState('')
   const [content, setContent] = useState('')
   const [submitting, setSubmitting] = useState(false)
@@ -257,13 +258,16 @@ export default function PostComments({ issueNumber }: Props) {
 
   const fetchComments = useCallback(async () => {
     setLoading(true)
+    setError(null)
     try {
       const res = await fetch(`/api/comments?issueNumber=${issueNumber}&limit=50`, { cache: 'no-store' })
+      if (!res.ok) throw new Error('评论加载失败')
       const data = await res.json()
       const list = data.data || data || []
+      if (!Array.isArray(list)) throw new Error('数据格式异常')
       setComments(list.filter((c: Comment) => c.status !== 'rejected'))
     } catch {
-      // Silent fail
+      setError('评论加载失败')
     } finally {
       setLoading(false)
     }
@@ -337,9 +341,7 @@ export default function PostComments({ issueNumber }: Props) {
       {loading ? (
         <LoadingState>加载中...</LoadingState>
       ) : comments.length === 0 ? (
-        <EmptyState>
-          还没有评论，来发表第一条吧。
-        </EmptyState>
+        error ? <EmptyState>{error}</EmptyState> : <EmptyState>还没有评论，来发表第一条吧。</EmptyState>
       ) : (
         comments.map((comment) => (
           <CommentItem key={comment._id || comment.externalId} $isGithub={isGithubComment(comment)}>


### PR DESCRIPTION
## 修复

1. **重复审批**: `approveAndPostToGitHub` 添加 `if (comment.status === 'approved') return comment`，防止重复发到 GitHub
2. **错误处理**: PostComments 添加 error 状态，fetch 失败时显示错误提示而非空状态

Closes #217