### PR TITLE
fix: 博客详情页评论功能入口缺失 (#219)

### DIFF
--- a/packages/wuh.site.next/app/post/PostView.tsx
+++ b/packages/wuh.site.next/app/post/PostView.tsx
@@ -12,6 +12,7 @@ import { useHeadingObserver } from './hooks/useHeadingObserver'
 import PostHeader from './components/PostHeader'
 import PostCover from './components/PostCover'
 import PostToolbar from './components/PostToolbar'
+import PostComments from './components/PostComments'
 import FloatingActions from './components/FloatingActions'
 import { openSharePopup, openWechatShareWindow } from '../share-utils'
 
@@ -26,7 +27,6 @@ import {
   ShareCardInner,
   ShareInfoCard,
   StatusEmpty,
-  CommentPlaceholder,
   TocAside,
   TocCard,
   TocItemLink,
@@ -251,7 +251,7 @@ export default function PostView({ issue, prevIssue, nextIssue, total, position 
             </ShareCardInner>
           </ShareInfoCard>
 
-          <CommentPlaceholder title='空空如也~' description='评论功能正在开发中，欢迎稍后回来留言交流。' />
+          <PostComments issueNumber={issue.number} />
 
           <PostToolbar prevIssue={prevIssue} nextIssue={nextIssue} currentNumber={issue.number} total={total} position={position} />
         </MainColumn>


### PR DESCRIPTION
## Bug

PR #216 的 PostView 改动被 sed 意外回退，博客详情页仍显示旧占位符。

## 修复

- 添加 `import PostComments`
- 替换 `<CommentPlaceholder>` 为 `<PostComments>`  
- 移除死引用 `CommentPlaceholder`

Closes #219