### PR TITLE
fix: next/image 缺少 src.wuh.site 域名白名单 (#222)

### DIFF
--- a/packages/wuh.site.next/next.config.ts
+++ b/packages/wuh.site.next/next.config.ts
@@ -27,7 +27,10 @@ const nextConfig: NextConfig = {
       {
         protocol: 'https',
         hostname: 'cdn.wuh.site',
-      },
+      {
+        protocol: 'https',
+        hostname: 'src.wuh.site',
+      },      },
     ],
   },
   // API rewrite to NestJS backend


### PR DESCRIPTION
## Bug

博客封面图托管在 `src.wuh.site`，`next.config.ts` 的 `images.remotePatterns` 里没有此域名，`next/image` 拦截了请求→图片加载失败。

## 修复

remotePatterns 增加 `src.wuh.site`。

Closes #222