### PR TITLE
fix: next.config.ts 语法错误 — 补回缺失的闭合括号 (#224)

### DIFF
--- a/packages/wuh.site.next/next.config.ts
+++ b/packages/wuh.site.next/next.config.ts
@@ -27,10 +27,11 @@ const nextConfig: NextConfig = {
       {
         protocol: 'https',
         hostname: 'cdn.wuh.site',
+      },
       {
         protocol: 'https',
         hostname: 'src.wuh.site',
-      },      },
+      },
     ],
   },
   // API rewrite to NestJS backend


### PR DESCRIPTION
## Bug

PR #223 的 sed 追加操作吞掉了 `cdn.wuh.site` 的 `},` 闭合括号，导致 TypeScript 语法错误，Docker 构建失败。

## 修复

补回缺失的 `},`。

Closes #224