### PR TITLE
feat: harden SEO crawl and canonical URLs

### DIFF
--- a/docs/superpowers/plans/2026-07-23-seo-p0.md
+++ b/docs/superpowers/plans/2026-07-23-seo-p0.md
@@ -1,0 +1,305 @@
+# SEO P0 基础修复实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 修复 wuh.site 文章 URL 规范化、sitemap 可抓取性、低价值页面索引和公共页面缓存策略，为后续 SEO 优化建立稳定基础。
+
+**Architecture:** 保留现有 `/post/{number}-{slug}` 站内 URL 作为 canonical；文章页以文章编号读取公共内容，非 canonical 路径通过永久重定向统一到当前标题 slug。Sitemap 通过分页获取已发布文章并只输出 canonical URL；互动数据仍由现有客户端 API 处理，不让文章页面读取用户 Cookie。
+
+**Tech Stack:** Next.js App Router 15、Metadata API、NestJS content API、Node test runner、TypeScript。
+
+---
+
+## 文件结构与责任
+
+- Modify: `packages/wuh.site.next/app/lib/slug.ts` — 提供 canonical 文章路径判断与 URL 生成。
+- Modify: `packages/wuh.site.next/app/post/[number]/page.tsx` — 移除 SEO 页面 Cookie 依赖、启用 ISR、规范化文章路径。
+- Modify: `packages/wuh.site.next/app/sitemap.ts` — 分页读取文章、输出 canonical URL、移除调试页面、使用真实更新时间。
+- Create: `packages/wuh.site.next/app/design/system-color/layout.tsx` — 为设计 Token 调试页面设置 `noindex`。
+- Modify: `packages/wuh.site.next/app/layout.tsx` — 增加全局 title template、description 与作者元数据。
+- Create: `packages/wuh.site.next/test/seo-p0.test.mjs` — 验证 URL、sitemap、metadata、缓存和 noindex 约束。
+- Create: `docs/superpowers/plans/2026-07-23-seo-p0.md` — 本实施计划。
+
+## Task 1: 建立 URL 规范化测试
+
+**Files:**
+- Test: `packages/wuh.site.next/test/seo-p0.test.mjs`
+- Modify: `packages/wuh.site.next/app/lib/slug.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```js
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { buildPostUrl, isCanonicalPostPath } from '../app/lib/slug.ts'
+
+test('builds a canonical post URL from number and title', () => {
+  assert.equal(buildPostUrl(123, 'Next.js #15 / SEO'), '/post/123-Next.js-15-SEO')
+})
+
+test('accepts only the current canonical post path', () => {
+  assert.equal(isCanonicalPostPath('123-Next.js-15-SEO', 123, 'Next.js #15 / SEO'), true)
+  assert.equal(isCanonicalPostPath('123', 123, 'Next.js #15 / SEO'), false)
+  assert.equal(isCanonicalPostPath('123-old-title', 123, 'Next.js #15 / SEO'), false)
+})
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+node --experimental-strip-types --test packages/wuh.site.next/test/seo-p0.test.mjs
+```
+
+Expected: FAIL because `isCanonicalPostPath` is not exported.
+
+- [ ] **Step 3: Implement the minimal URL helper**
+
+Add the following helper to `packages/wuh.site.next/app/lib/slug.ts`:
+
+```ts
+export function isCanonicalPostPath(pathname: string, number: number | string, title: string): boolean {
+  return pathname === `${number}-${toSlug(title)}`
+}
+```
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run the same command. Expected: 2 tests pass.
+
+## Task 2: Enforce canonical post redirects and ISR
+
+**Files:**
+- Test: `packages/wuh.site.next/test/seo-p0.test.mjs`
+- Modify: `packages/wuh.site.next/app/post/[number]/page.tsx`
+
+- [ ] **Step 1: Add source-level regression tests for public rendering constraints**
+
+```js
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const testDir = dirname(fileURLToPath(import.meta.url))
+const appRoot = resolve(testDir, '..')
+const postPageSource = await readFile(resolve(appRoot, 'app/post/[number]/page.tsx'), 'utf8')
+
+
+test('post SEO rendering does not depend on request cookies and uses ISR', () => {
+  assert.doesNotMatch(postPageSource, /from ['"]next\/headers['"]|cookies\(/)
+  assert.match(postPageSource, /revalidate:\s*3600/)
+})
+
+test('post page redirects non-canonical paths permanently', () => {
+  assert.match(postPageSource, /permanentRedirect/)
+  assert.match(postPageSource, /isCanonicalPostPath/)
+})
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Expected: FAIL because the page imports `cookies`, uses `revalidate: 0`, and has no permanent redirect.
+
+- [ ] **Step 3: Implement the minimal server-page change**
+
+In `packages/wuh.site.next/app/post/[number]/page.tsx`:
+
+1. Remove `cookies` import, `ANON_COOKIE_NAME`, and `getAnonCookieHeader`.
+2. Import `permanentRedirect` from `next/navigation` and `isCanonicalPostPath`.
+3. Change the article fetch to:
+
+```ts
+const { data, error } = await contentService.getPost.server({
+  params: { slug: num },
+  revalidate: 3600,
+})
+```
+
+4. In `generateMetadata`, derive canonical URL from the loaded article and keep it in `alternates.canonical`.
+5. In the page component, after loading the article and before rendering, redirect non-canonical paths:
+
+```ts
+if (!isCanonicalPostPath(raw, issue.number, issue.title)) {
+  permanentRedirect(buildPostUrl(issue.number, issue.title))
+}
+```
+
+The `raw` value is the full dynamic route segment, while `number` remains the numeric lookup key.
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Expected: all URL and post-page regression tests pass.
+
+## Task 3: Add sitemap helpers and pagination tests
+
+**Files:**
+- Test: `packages/wuh.site.next/test/seo-p0.test.mjs`
+- Modify: `packages/wuh.site.next/app/sitemap.ts`
+
+- [ ] **Step 1: Add failing sitemap tests**
+
+```js
+import { buildPostSitemapEntry, buildStaticSitemapRoutes } from '../app/sitemap.ts'
+
+test('sitemap uses the canonical slug URL', () => {
+  const entry = buildPostSitemapEntry({
+    number: 123,
+    title: 'Next.js SEO',
+    updatedAtGitHub: '2026-07-20T00:00:00.000Z',
+    createdAtGitHub: '2026-07-19T00:00:00.000Z',
+  })
+
+  assert.equal(entry.url, 'https://wuh.site/post/123-Next.js-SEO')
+  assert.equal(entry.lastModified.toISOString(), '2026-07-20T00:00:00.000Z')
+})
+
+test('static sitemap excludes the design token debug page', () => {
+  const urls = buildStaticSitemapRoutes().map((route) => route.url)
+  assert.equal(urls.includes('https://wuh.site/design/system-color'), false)
+  assert.equal(urls.includes('https://wuh.site/blog'), true)
+})
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Expected: FAIL because the sitemap helper exports do not exist and the current post URL is numeric-only.
+
+- [ ] **Step 3: Implement sitemap helpers and paginated loading**
+
+In `packages/wuh.site.next/app/sitemap.ts`:
+
+1. Import `buildPostUrl`.
+2. Export `buildStaticSitemapRoutes()` returning only `/`, `/blog`, and `/about`.
+3. Export `buildPostSitemapEntry(post)` that uses `buildPostUrl(post.number, post.title)` and `new Date(post.updatedAtGitHub || post.createdAtGitHub)`.
+4. Set `SITEMAP_PAGE_SIZE = 100`.
+5. Fetch page 1, then continue while `result.pagination.hasNextPage` is true. Every request must use `state: 'open'`, the fixed page size, and `revalidate: 3600`.
+6. If any page fails, throw an explicit error instead of silently returning an incomplete sitemap.
+7. Return static routes plus all canonical post entries.
+8. Do not include `lastModified: new Date()` for static routes; omit it until a real page-level timestamp exists.
+
+The endpoint currently accepts `page` and `limit` and returns `pagination.hasNextPage`, so no API contract change is required for this task.
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Expected: sitemap helper tests pass.
+
+## Task 4: Add noindex metadata and global metadata defaults
+
+**Files:**
+- Test: `packages/wuh.site.next/test/seo-p0.test.mjs`
+- Create: `packages/wuh.site.next/app/design/system-color/layout.tsx`
+- Modify: `packages/wuh.site.next/app/layout.tsx`
+
+- [ ] **Step 1: Add failing metadata tests**
+
+```js
+const rootLayoutSource = await readFile(resolve(appRoot, 'app/layout.tsx'), 'utf8')
+const designLayoutPath = resolve(appRoot, 'app/design/system-color/layout.tsx')
+let designLayoutSource = ''
+try {
+  designLayoutSource = await readFile(designLayoutPath, 'utf8')
+} catch {}
+
+test('root metadata provides a title template and default description', () => {
+  assert.match(rootLayoutSource, /title:\s*\{/)
+  assert.match(rootLayoutSource, /template:\s*['"]%s · wuh\.site['"]|template:\s*['"]%s · wuh\.site['"]/) 
+  assert.match(rootLayoutSource, /description:/)
+})
+
+test('design token page is noindex', () => {
+  assert.match(designLayoutSource, /index:\s*false/)
+  assert.match(designLayoutSource, /follow:\s*false/)
+})
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Expected: FAIL because root metadata has no title template and the design page has no layout.
+
+- [ ] **Step 3: Implement metadata defaults**
+
+In `packages/wuh.site.next/app/layout.tsx`, add:
+
+```ts
+export const metadata: Metadata = {
+  metadataBase: new URL('https://wuh.site'),
+  title: {
+    default: 'wuh.site · 朝朝如念',
+    template: '%s · wuh.site',
+  },
+  description: '记录前端工程、开源项目、设计系统与个人思考。',
+  authors: [{ name: 'shadow', url: 'https://github.com/stack-wuh' }],
+  creator: 'shadow',
+  publisher: 'wuh.site',
+  robots: { index: true, follow: true },
+}
+```
+
+Create `packages/wuh.site.next/app/design/system-color/layout.tsx`:
+
+```tsx
+import type { ReactNode } from 'react'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Design Token 调试面板',
+  description: 'wuh.site 内部设计 Token 调试页面。',
+  robots: { index: false, follow: false },
+}
+
+export default function DesignSystemLayout({ children }: { children: ReactNode }) {
+  return children
+}
+```
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Expected: metadata tests pass.
+
+## Task 5: Run full verification
+
+**Files:**
+- No additional files.
+
+- [ ] **Step 1: Run all frontend tests**
+
+```bash
+node --experimental-strip-types --test packages/wuh.site.next/test/*.test.mjs
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run frontend lint**
+
+```bash
+pnpm --filter @wuh.site/next run lint
+```
+
+Expected: exit code 0. If the shared local dependency installation is unavailable, record the exact environment error separately and continue with direct TypeScript checks where possible.
+
+- [ ] **Step 3: Run TypeScript validation**
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+Expected: no new errors caused by SEO changes.
+
+- [ ] **Step 4: Run the Next.js production build**
+
+```bash
+pnpm --filter @wuh.site/next run build
+```
+
+Expected: build succeeds. If the API is unavailable in the environment, distinguish route/data failures from compile failures.
+
+- [ ] **Step 5: Review the final diff and worktree status**
+
+```bash
+git diff --check
+git status --short
+git diff --stat
+```
+
+Expected: only P0 SEO files and the plan/test files are changed; no generated build artifacts are committed.

--- a/packages/wuh.site.next/app/about/layout.tsx
+++ b/packages/wuh.site.next/app/about/layout.tsx
@@ -4,11 +4,11 @@ import type { Metadata } from 'next'
 const SITE_URL = 'https://wuh.site'
 
 export const metadata: Metadata = {
-  title: '关于 · wuh.site',
+  title: '关于',
   description: '数据驱动的作者日记，以 GitHub 热力图为灵感，汇聚创作故事',
   alternates: { canonical: `${SITE_URL}/about` },
   openGraph: {
-    title: '关于 · wuh.site',
+    title: '关于',
     description: '数据驱动的作者日记，以 GitHub 热力图为灵感',
     url: `${SITE_URL}/about`,
     siteName: 'wuh.site',
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary',
-    title: '关于 · wuh.site',
+    title: '关于',
     description: '数据驱动的作者日记',
   },
 }

--- a/packages/wuh.site.next/app/about/page.tsx
+++ b/packages/wuh.site.next/app/about/page.tsx
@@ -6,12 +6,12 @@ import AboutView from './AboutView'
 const SITE_URL = 'https://wuh.site'
 
 export const metadata: Metadata = {
-  title: 'About · wuh.site',
+  title: '关于',
   description: '输出节奏总览 — 记录思考，串联碎片，构建自己的知识系统',
   robots: { index: true, follow: true },
   alternates: { canonical: `${SITE_URL}/about` },
   openGraph: {
-    title: 'About · wuh.site',
+    title: '关于',
     description: '输出节奏总览 — 记录思考，串联碎片，构建自己的知识系统',
     url: `${SITE_URL}/about`,
     siteName: 'wuh.site',

--- a/packages/wuh.site.next/app/blog/page.tsx
+++ b/packages/wuh.site.next/app/blog/page.tsx
@@ -7,7 +7,7 @@ import { toLabelParams } from './blog-filter-utils'
 const SITE_URL = 'https://wuh.site'
 
 export const metadata: Metadata = {
-  title: '博客 · wuh.site',
+  title: '博客',
   description: '收录 GitHub Issues 中的全部博客文章',
   robots: { index: true, follow: true },
   alternates: { canonical: `${SITE_URL}/blog` },

--- a/packages/wuh.site.next/app/design/system-color/layout.tsx
+++ b/packages/wuh.site.next/app/design/system-color/layout.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from 'react'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Design Token 调试面板',
+  description: 'wuh.site 内部设计 Token 调试页面。',
+  robots: { index: false, follow: false },
+}
+
+export default function DesignSystemLayout({ children }: { children: ReactNode }) {
+  return children
+}

--- a/packages/wuh.site.next/app/footprint/layout.tsx
+++ b/packages/wuh.site.next/app/footprint/layout.tsx
@@ -4,11 +4,11 @@ import type { Metadata } from 'next'
 const SITE_URL = 'https://wuh.site'
 
 export const metadata: Metadata = {
-  title: '足迹 · wuh.site',
+  title: '足迹',
   description: '深圳周边的旅游足迹记录，探索路线与风景',
   alternates: { canonical: `${SITE_URL}/footprint` },
   openGraph: {
-    title: '足迹 · wuh.site',
+    title: '足迹',
     description: '深圳周边的旅游足迹记录',
     url: `${SITE_URL}/footprint`,
     siteName: 'wuh.site',
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary',
-    title: '足迹 · wuh.site',
+    title: '足迹',
     description: '深圳周边的旅游足迹记录',
   },
 }

--- a/packages/wuh.site.next/app/layout.tsx
+++ b/packages/wuh.site.next/app/layout.tsx
@@ -18,6 +18,14 @@ const notoSerifSC = Noto_Serif_SC({
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://wuh.site'),
+  title: {
+    default: 'wuh.site · 朝朝如念',
+    template: '%s · wuh.site',
+  },
+  description: '记录前端工程、开源项目、设计系统与个人思考。',
+  authors: [{ name: 'shadow', url: 'https://github.com/stack-wuh' }],
+  creator: 'shadow',
+  publisher: 'wuh.site',
   robots: { index: true, follow: true },
 }
 

--- a/packages/wuh.site.next/app/lib/sitemap.ts
+++ b/packages/wuh.site.next/app/lib/sitemap.ts
@@ -1,0 +1,30 @@
+import type { MetadataRoute } from 'next'
+import { buildPostUrl } from './slug.ts'
+
+export const SITE_URL = 'https://wuh.site'
+
+export type SitemapPost = {
+  number: number
+  title: string
+  updatedAtGitHub?: string | null
+  createdAtGitHub?: string | null
+}
+
+export function buildStaticSitemapRoutes(): MetadataRoute.Sitemap {
+  return [
+    { url: SITE_URL, changeFrequency: 'daily', priority: 1.0 },
+    { url: `${SITE_URL}/blog`, changeFrequency: 'daily', priority: 0.8 },
+    { url: `${SITE_URL}/about`, changeFrequency: 'monthly', priority: 0.5 },
+  ]
+}
+
+export function buildPostSitemapEntry(post: SitemapPost): MetadataRoute.Sitemap[number] {
+  const lastModified = post.updatedAtGitHub || post.createdAtGitHub
+
+  return {
+    url: `${SITE_URL}${buildPostUrl(post.number, post.title)}`,
+    ...(lastModified ? { lastModified: new Date(lastModified) } : {}),
+    changeFrequency: 'weekly',
+    priority: 0.6,
+  }
+}

--- a/packages/wuh.site.next/app/lib/slug.ts
+++ b/packages/wuh.site.next/app/lib/slug.ts
@@ -1,10 +1,15 @@
 export function toSlug(title: string): string {
   return title
-    .replace(/[#?&/\\]/g, '-')
+    .trim()
+    .replace(/[\s#?&/\\]+/g, '-')
     .replace(/-+/g, '-')
     .replace(/^-|-$/g, '')
 }
 
 export function buildPostUrl(number: number | string, title: string): string {
   return `/post/${number}-${toSlug(title)}`
+}
+
+export function isCanonicalPostPath(pathname: string, number: number | string, title: string): boolean {
+  return pathname === `${number}-${toSlug(title)}`
 }

--- a/packages/wuh.site.next/app/page.tsx
+++ b/packages/wuh.site.next/app/page.tsx
@@ -5,7 +5,6 @@ import HomeView from './HomeView'
 
 const SITE_URL = 'https://wuh.site'
 
-export const dynamic = 'force-dynamic'
 
 function logHomeFetchError(moduleName: string, error: unknown) {
   const message = error instanceof Error ? error.message : JSON.stringify(error)
@@ -13,12 +12,12 @@ function logHomeFetchError(moduleName: string, error: unknown) {
 }
 
 export const metadata: Metadata = {
-  title: 'wuh.site · 朝朝如念',
+  title: '朝朝如念',
   description: '基于 Next.js 的个人站，汇集 GitHub 项目、文章与工具',
   robots: { index: true, follow: true },
   alternates: { canonical: SITE_URL },
   openGraph: {
-    title: 'wuh.site · 朝朝如念',
+    title: '朝朝如念',
     description: '基于 Next.js 的个人站，汇集 GitHub 项目、文章与工具',
     url: SITE_URL,
     siteName: 'wuh.site',
@@ -26,7 +25,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary',
-    title: 'wuh.site · 朝朝如念',
+    title: '朝朝如念',
     description: '基于 Next.js 的个人站，汇集 GitHub 项目、文章与工具',
   },
 }

--- a/packages/wuh.site.next/app/post/[number]/page.tsx
+++ b/packages/wuh.site.next/app/post/[number]/page.tsx
@@ -1,22 +1,15 @@
 import { cache } from 'react'
 import type { Metadata } from 'next'
-import { cookies } from 'next/headers'
+import { permanentRedirect } from 'next/navigation'
 import { contentService } from '@wuh.site/shared-contracts/endpoints'
 import { renderMarkdown } from '../../lib/markdown'
-import { buildPostUrl } from '../../lib/slug'
+import { buildPostUrl, isCanonicalPostPath } from '../../lib/slug'
 import type { ContentItem, AdjacentPost } from '@wuh.site/shared-contracts'
 import PostView from '../PostView'
 import type { Issue } from '../PostView.types'
 import JsonLd from '../../components/JsonLd'
 
 const SITE_URL = 'https://wuh.site'
-const ANON_COOKIE_NAME = 'anonId'
-
-async function getAnonCookieHeader() {
-  const anonId = (await cookies()).get(ANON_COOKIE_NAME)?.value
-  if (!anonId) return undefined
-  return `${ANON_COOKIE_NAME}=${encodeURIComponent(anonId)}`
-}
 
 function buildDescription(issue: Issue): string {
   if (issue.metadata?.summary) return issue.metadata.summary
@@ -28,7 +21,7 @@ function buildDescription(issue: Issue): string {
 }
 
 const FALLBACK_METADATA: Metadata = {
-  title: '博客详情 · wuh.site',
+  title: '博客详情',
   description: '阅读这篇博客文章',
 }
 
@@ -69,11 +62,10 @@ type IssueData = {
   position: number
 }
 
-const getIssue = cache(async (num: string, cookie?: string): Promise<IssueData> => {
+const getIssue = cache(async (num: string): Promise<IssueData> => {
   const { data, error } = await contentService.getPost.server({
     params: { slug: num },
-    revalidate: 0,
-    headers: cookie ? { Cookie: cookie } : undefined,
+    revalidate: 3600,
   })
 
   if (error || !data) {
@@ -97,8 +89,7 @@ const getIssue = cache(async (num: string, cookie?: string): Promise<IssueData> 
 export async function generateMetadata({ params }: { params: Promise<{ number: string }> }): Promise<Metadata> {
   const { number: raw } = await params
   const number = raw.split('-')[0]
-  const cookie = await getAnonCookieHeader()
-  const { issue } = await getIssue(number, cookie)
+  const { issue } = await getIssue(number)
 
   if (!issue) {
     return FALLBACK_METADATA
@@ -109,7 +100,7 @@ export async function generateMetadata({ params }: { params: Promise<{ number: s
   const cover = issue.metadata?.cover
 
   return {
-    title: `${issue.title} · wuh.site`,
+    title: issue.title,
     description,
     alternates: { canonical: url },
     openGraph: {
@@ -134,9 +125,12 @@ export async function generateMetadata({ params }: { params: Promise<{ number: s
 export default async function Page({ params }: { params: Promise<{ number: string }> }) {
   const { number: raw } = await params;
   const number = raw.split('-')[0];
-  const cookie = await getAnonCookieHeader()
-  const { issue, prev: prevIssue, next: nextIssue, total, position } = await getIssue(number, cookie);
-  if (!issue) return <PostView issue={null} prevIssue={null} nextIssue={null} />;
+  const { issue, prev: prevIssue, next: nextIssue, total, position } = await getIssue(number)
+  if (!issue) return <PostView issue={null} prevIssue={null} nextIssue={null} />
+
+  if (!isCanonicalPostPath(raw, issue.number, issue.title)) {
+    permanentRedirect(buildPostUrl(issue.number, issue.title))
+  }
 
   const jsonLd = {
     '@context': 'https://schema.org',
@@ -159,5 +153,5 @@ export default async function Page({ params }: { params: Promise<{ number: strin
       <JsonLd data={jsonLd as unknown as Record<string, unknown>} />
       <PostView issue={issue} prevIssue={prevIssue} nextIssue={nextIssue} total={total} position={position} />
     </>
-  );
+  )
 }

--- a/packages/wuh.site.next/app/sitemap.ts
+++ b/packages/wuh.site.next/app/sitemap.ts
@@ -1,31 +1,52 @@
 import { type MetadataRoute } from 'next'
 import { contentService } from '@wuh.site/shared-contracts/endpoints'
+import {
+  buildPostSitemapEntry,
+  buildStaticSitemapRoutes,
+  type SitemapPost,
+} from './lib/sitemap'
 
-const SITE_URL = 'https://wuh.site'
+const SITEMAP_PAGE_SIZE = 100
 
-const staticRoutes: MetadataRoute.Sitemap = [
-  { url: SITE_URL, lastModified: new Date(), changeFrequency: 'daily', priority: 1.0 },
-  { url: `${SITE_URL}/blog`, lastModified: new Date(), changeFrequency: 'daily', priority: 0.8 },
-  { url: `${SITE_URL}/about`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.5 },
-  { url: `${SITE_URL}/design/system-color`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.3 },
-]
+type SitemapPostsResponse = {
+  data: SitemapPost[]
+  pagination?: {
+    hasNextPage?: boolean
+  }
+}
 
-export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const { data, error } = await contentService.getPosts.server({
-    query: { limit: '9999', state: 'open' },
-  })
+async function getPublishedPosts(): Promise<SitemapPost[]> {
+  const posts: SitemapPost[] = []
+  let page = 1
 
-  if (error || !data) {
-    return staticRoutes
+  while (true) {
+    const { data, error } = await contentService.getPosts.server({
+      query: {
+        page: String(page),
+        limit: String(SITEMAP_PAGE_SIZE),
+        state: 'open',
+      },
+      revalidate: 3600,
+    })
+
+    if (error || !data) {
+      throw new Error(`Failed to load sitemap posts on page ${page}`)
+    }
+
+    const result = data as SitemapPostsResponse
+    posts.push(...(result.data || []))
+
+    if (!result.pagination?.hasNextPage) break
+    page += 1
   }
 
-  const result = data as any
-  const postRoutes: MetadataRoute.Sitemap = (result.data || []).map((post: any) => ({
-    url: `${SITE_URL}/post/${post.number}`,
-    lastModified: new Date(post.updatedAtGitHub || post.createdAtGitHub),
-    changeFrequency: 'weekly' as const,
-    priority: 0.6,
-  }))
+  return posts
+}
 
-  return [...staticRoutes, ...postRoutes]
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const posts = await getPublishedPosts()
+  return [
+    ...buildStaticSitemapRoutes(),
+    ...posts.map(buildPostSitemapEntry),
+  ]
 }

--- a/packages/wuh.site.next/app/weread/page.tsx
+++ b/packages/wuh.site.next/app/weread/page.tsx
@@ -7,11 +7,11 @@ const SITE_URL = 'https://wuh.site'
 const PER_PAGE = 10
 
 export const metadata: Metadata = {
-  title: '微信读书 · wuh.site',
+  title: '微信读书',
   description: 'stack-wuh 的微信读书书架',
   alternates: { canonical: `${SITE_URL}/weread` },
   openGraph: {
-    title: '微信读书 · wuh.site',
+    title: '微信读书',
     description: 'stack-wuh 的微信读书书架',
     url: `${SITE_URL}/weread`,
     siteName: 'wuh.site',

--- a/packages/wuh.site.next/test/seo-p0.test.mjs
+++ b/packages/wuh.site.next/test/seo-p0.test.mjs
@@ -1,0 +1,73 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { buildPostUrl, isCanonicalPostPath } from '../app/lib/slug.ts'
+
+const testDir = dirname(fileURLToPath(import.meta.url))
+const appRoot = resolve(testDir, '..')
+const postPageSource = await readFile(resolve(appRoot, 'app/post/[number]/page.tsx'), 'utf8')
+const homePageSource = await readFile(resolve(appRoot, 'app/page.tsx'), 'utf8')
+const rootLayoutSource = await readFile(resolve(appRoot, 'app/layout.tsx'), 'utf8')
+const designLayoutPath = resolve(appRoot, 'app/design/system-color/layout.tsx')
+let designLayoutSource = ''
+try {
+  designLayoutSource = await readFile(designLayoutPath, 'utf8')
+} catch {}
+
+test('builds a canonical post URL from number and title', () => {
+  assert.equal(buildPostUrl(123, 'Next.js #15 / SEO'), '/post/123-Next.js-15-SEO')
+})
+
+test('accepts only the current canonical post path', () => {
+  assert.equal(isCanonicalPostPath('123-Next.js-15-SEO', 123, 'Next.js #15 / SEO'), true)
+  assert.equal(isCanonicalPostPath('123', 123, 'Next.js #15 / SEO'), false)
+  assert.equal(isCanonicalPostPath('123-old-title', 123, 'Next.js #15 / SEO'), false)
+})
+
+test('post SEO rendering does not depend on request cookies and uses ISR', () => {
+  assert.doesNotMatch(postPageSource, /from ['"]next\/headers['"]|cookies\(/)
+  assert.match(postPageSource, /revalidate:\s*3600/)
+})
+
+test('post page redirects non-canonical paths permanently', () => {
+  assert.match(postPageSource, /permanentRedirect/)
+  assert.match(postPageSource, /isCanonicalPostPath/)
+})
+
+test('home page uses revalidated data instead of force-dynamic rendering', () => {
+  assert.doesNotMatch(homePageSource, /force-dynamic/)
+  assert.match(homePageSource, /revalidate:\s*1800/)
+})
+
+test('sitemap uses the canonical slug URL', async () => {
+  const { buildPostSitemapEntry } = await import('../app/lib/sitemap.ts')
+  const entry = buildPostSitemapEntry({
+    number: 123,
+    title: 'Next.js SEO',
+    updatedAtGitHub: '2026-07-20T00:00:00.000Z',
+    createdAtGitHub: '2026-07-19T00:00:00.000Z',
+  })
+
+  assert.equal(entry.url, 'https://wuh.site/post/123-Next.js-SEO')
+  assert.equal(entry.lastModified.toISOString(), '2026-07-20T00:00:00.000Z')
+})
+
+test('static sitemap excludes the design token debug page', async () => {
+  const { buildStaticSitemapRoutes } = await import('../app/lib/sitemap.ts')
+  const urls = buildStaticSitemapRoutes().map((route) => route.url)
+  assert.equal(urls.includes('https://wuh.site/design/system-color'), false)
+  assert.equal(urls.includes('https://wuh.site/blog'), true)
+})
+
+test('root metadata provides a title template and default description', () => {
+  assert.match(rootLayoutSource, /title:\s*\{/) 
+  assert.match(rootLayoutSource, /template:\s*['"]%s · wuh\.site['"]/) 
+  assert.match(rootLayoutSource, /description:/)
+})
+
+test('design token page is noindex', () => {
+  assert.match(designLayoutSource, /index:\s*false/)
+  assert.match(designLayoutSource, /follow:\s*false/)
+})


### PR DESCRIPTION
## 变更概述

实现 Issue #233 的 SEO P0 基础修复：

- 统一文章 canonical URL 与 sitemap URL。
- 错误 slug、数字 URL 永久重定向到规范文章 URL。
- 文章详情和首页移除不必要的动态渲染约束，启用 ISR。
- Sitemap 改为分页读取，并使用真实更新时间。
- 移除设计 Token 调试页的 sitemap 条目并设置 noindex。
- 增加全局 metadata 默认值和 title template。
- 修正子页面 metadata，避免 title 重复追加站点名。
- 增加 SEO P0 回归测试。

## 验证

- 17 个测试用例通过（分文件串行执行）。
- Oxlint 通过。
- TypeScript 检查通过。
- `git diff --check` 通过。
- Next.js production build 在当前环境及原工作区基线均触发 build worker SIGSEGV，已记录到 Issue #233，需在 CI/完整依赖环境复验。

## 关联 Issue

Refs #233

> P1 结构化数据、Breadcrumb、作者页、主题聚合页和相关文章结构将在后续 PR 中继续拆分，避免本 PR 范围过大。
