### PR TITLE
feat: add related post links

### DIFF
--- a/docs/superpowers/plans/2026-07-24-seo-p12-related-posts.md
+++ b/docs/superpowers/plans/2026-07-24-seo-p12-related-posts.md
@@ -1,0 +1,163 @@
+# SEO P1.2 Related Posts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在文章详情页展示最多三篇按标签相关度排序的相关文章，增加规范化的语义内部链接。
+
+**Architecture:** 文章服务端页面用当前文章最多三个标签并发获取候选文章；纯函数负责排除当前文章、去重、按共享标签数和更新时间排序并截取前三项。客户端 PostView 仅负责在有结果时渲染语义化 section，所有链接复用 `buildPostUrl`。
+
+**Tech Stack:** Next.js App Router、TypeScript、styled-components、Node test runner、现有 Content API。
+
+---
+
+## 文件结构
+
+- Create: `packages/wuh.site.next/app/lib/related-posts.ts` — 候选文章映射与排序纯函数。
+- Modify: `packages/wuh.site.next/app/post/PostView.types.ts` — 定义 RelatedPost 和 props。
+- Modify: `packages/wuh.site.next/app/post/[number]/page.tsx` — 按标签获取候选文章并传给视图。
+- Modify: `packages/wuh.site.next/app/post/PostView.tsx` — 条件渲染相关文章 section。
+- Modify: `packages/wuh.site.next/app/post/styles/post-article.ts` — 相关文章样式。
+- Modify: `packages/wuh.site.next/app/post/styles/index.ts` — 导出相关文章样式。
+- Create: `packages/wuh.site.next/test/related-posts.test.mjs` — 相关度排序和去重测试。
+- Create: `packages/wuh.site.next/test/seo-p12-related-posts.test.mjs` — 页面与可见内部链接回归测试。
+
+## Task 1: 候选筛选的失败测试
+
+**Files:**
+- Test: `packages/wuh.site.next/test/related-posts.test.mjs`
+- Create: `packages/wuh.site.next/app/lib/related-posts.ts`
+
+- [ ] **Step 1: 写失败测试**
+
+```js
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { selectRelatedPosts } from '../app/lib/related-posts.ts'
+
+test('selects unique related posts by shared labels and recency', () => {
+  const posts = selectRelatedPosts(
+    { number: 10, labels: ['Next.js', 'SEO'] },
+    [
+      { number: 10, title: '当前文章', labels: ['Next.js'], updatedAt: '2026-07-22' },
+      { number: 11, title: '两个标签', labels: ['Next.js', 'SEO'], updatedAt: '2026-07-20' },
+      { number: 12, title: '一个标签较新', labels: ['SEO'], updatedAt: '2026-07-23' },
+      { number: 12, title: '重复数据', labels: ['SEO'], updatedAt: '2026-07-19' },
+      { number: 13, title: '无关文章', labels: ['NestJS'], updatedAt: '2026-07-24' },
+    ],
+  )
+
+  assert.deepEqual(posts.map((post) => post.number), [11, 12])
+})
+
+test('caps related posts at three items', () => {
+  const posts = selectRelatedPosts(
+    { number: 10, labels: ['Next.js'] },
+    [11, 12, 13, 14].map((number) => ({
+      number,
+      title: `文章 ${number}`,
+      labels: ['Next.js'],
+      updatedAt: `2026-07-${number}`,
+    })),
+  )
+
+  assert.equal(posts.length, 3)
+})
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+```bash
+/Users/wuhong/.nvm/versions/node/v22.22.3/bin/node --experimental-strip-types --test packages/wuh.site.next/test/related-posts.test.mjs
+```
+
+Expected: module-not-found for the new helper.
+
+- [ ] **Step 3: 最小实现纯筛选函数**
+
+接受当前文章 number/labels 与候选项；排除当前编号，跳过无共享标签项，按 shared label count 降序、updatedAt 降序、number 升序排序，用 number 去重，返回 3 项。
+
+- [ ] **Step 4: 重跑测试确认通过**
+
+## Task 2: 服务端获取相关文章
+
+**Files:**
+- Test: `packages/wuh.site.next/test/seo-p12-related-posts.test.mjs`
+- Modify: `packages/wuh.site.next/app/post/[number]/page.tsx`
+- Modify: `packages/wuh.site.next/app/post/PostView.types.ts`
+
+- [ ] **Step 1: 增加失败的页面测试**
+
+测试必须断言文章页面包含：`getRelatedPosts`、标签 `Promise.all`、`revalidate: 3600`、`selectRelatedPosts`，并将 `relatedPosts` 传给 `PostView`。
+
+- [ ] **Step 2: 运行并确认失败**
+
+- [ ] **Step 3: 实现候选获取与映射**
+
+从 `issue.labels` 提取最多三个非空标签。每个标签请求：
+
+```ts
+contentService.getPosts.server({
+  query: { labels: [label], limit: '10', state: 'open' },
+  revalidate: 3600,
+})
+```
+
+把成功响应的 `ContentItem` 映射成 RelatedPost 候选，调用 `selectRelatedPosts`。无标签和请求失败返回空数组。将结果通过 `relatedPosts` prop 传入 `PostView`。
+
+- [ ] **Step 4: 重跑页面测试确认通过**
+
+## Task 3: 渲染语义化相关文章模块
+
+**Files:**
+- Test: `packages/wuh.site.next/test/seo-p12-related-posts.test.mjs`
+- Modify: `packages/wuh.site.next/app/post/PostView.tsx`
+- Modify: `packages/wuh.site.next/app/post/styles/post-article.ts`
+- Modify: `packages/wuh.site.next/app/post/styles/index.ts`
+
+- [ ] **Step 1: 添加失败的视图测试**
+
+断言 `PostView`：
+
+- 读取 `relatedPosts` props；
+- 仅在 `relatedPosts.length > 0` 时渲染 `RelatedPostsSection`；
+- section 有 `aria-labelledby='related-posts-title'`；
+- 每篇文章使用 `buildPostUrl(post.number, post.title)`。
+
+- [ ] **Step 2: 运行并确认失败**
+
+- [ ] **Step 3: 最小实现组件和样式**
+
+在 `ArticleCard` 后、`ImagePreview` 前渲染 `<section>`，其中为 `<h2 id='related-posts-title'>相关文章</h2>` 和 `<ul>`。每篇内容显示标题与最多两个共同标签，链接为 canonical URL。空数组不渲染。
+
+- [ ] **Step 4: 重跑测试确认通过**
+
+## Task 4: 验证、提交、推送和创建链式 PR
+
+- [ ] **Step 1: 运行全部前端测试文件**
+
+```bash
+NODE=/Users/wuhong/.nvm/versions/node/v22.22.3/bin/node
+for test_file in packages/wuh.site.next/test/*.test.mjs; do
+  "$NODE" --experimental-strip-types --test-concurrency=1 --test "$test_file"
+done
+```
+
+- [ ] **Step 2: lint、diff 和 TypeScript 尝试**
+
+```bash
+/Users/wuhong/shadow-desktop/github/x.wuh.site/node_modules/.pnpm/oxlint@1.69.0/node_modules/oxlint/bin/oxlint app
+git diff --check
+node /Users/wuhong/shadow-desktop/github/x.wuh.site/node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/bin/tsc --noEmit --project tsconfig.json --pretty false
+```
+
+记录任何环境级 TypeScript SIGSEGV，不把它误报为通过。
+
+- [ ] **Step 3: 提交、推送并创建 PR**
+
+```bash
+git add docs/superpowers/plans/2026-07-24-seo-p12-related-posts.md packages/wuh.site.next
+git commit -m "feat: add related post links"
+git push -u origin codex/seo-p12
+```
+
+PR base 为 `codex/seo-p1`，关联 `Refs #238`；在 #238 写入提交号、PR 和验证证据。

--- a/packages/wuh.site.next/app/lib/related-posts.ts
+++ b/packages/wuh.site.next/app/lib/related-posts.ts
@@ -1,0 +1,54 @@
+export type RelatedPostCandidate = {
+  number: number
+  title: string
+  labels: string[]
+  updatedAt: string
+  summary?: string | null
+}
+
+export type RelatedPost = RelatedPostCandidate & {
+  sharedLabels: string[]
+}
+
+type CurrentPost = {
+  number: number
+  labels: string[]
+}
+
+function normalizeLabels(labels: string[]): string[] {
+  return Array.from(new Set(labels.map((label) => label.trim()).filter(Boolean)))
+}
+
+function toTimestamp(value: string): number {
+  const timestamp = Date.parse(value)
+  return Number.isNaN(timestamp) ? 0 : timestamp
+}
+
+export function selectRelatedPosts(currentPost: CurrentPost, candidates: RelatedPostCandidate[]): RelatedPost[] {
+  const currentLabels = new Set(normalizeLabels(currentPost.labels))
+  const ranked = candidates
+    .filter((candidate) => candidate.number !== currentPost.number)
+    .map((candidate) => ({
+      ...candidate,
+      sharedLabels: normalizeLabels(candidate.labels).filter((label) => currentLabels.has(label)),
+    }))
+    .filter((candidate) => candidate.sharedLabels.length > 0)
+    .sort((left, right) => {
+      const sharedLabelsDifference = right.sharedLabels.length - left.sharedLabels.length
+      if (sharedLabelsDifference !== 0) return sharedLabelsDifference
+
+      const updatedAtDifference = toTimestamp(right.updatedAt) - toTimestamp(left.updatedAt)
+      if (updatedAtDifference !== 0) return updatedAtDifference
+
+      return left.number - right.number
+    })
+
+  const seenNumbers = new Set<number>()
+  const uniquePosts = ranked.filter((candidate) => {
+    if (seenNumbers.has(candidate.number)) return false
+    seenNumbers.add(candidate.number)
+    return true
+  })
+
+  return uniquePosts.slice(0, 3)
+}

--- a/packages/wuh.site.next/app/post/PostView.tsx
+++ b/packages/wuh.site.next/app/post/PostView.tsx
@@ -28,6 +28,10 @@ import {
   MarkdownBody,
   PostLead,
   RedundantInfoCard,
+  RelatedPostLabels,
+  RelatedPostLink,
+  RelatedPostsSection,
+  RelatedPostTitle,
   ShareCardInner,
   ShareInfoCard,
   StatusEmpty,
@@ -159,7 +163,7 @@ const createShareItems = (issue: Issue): ShareItem[] => {
   ]
 }
 
-export default function PostView({ issue, prevIssue, nextIssue, total, position }: PostViewProps) {
+export default function PostView({ issue, prevIssue, nextIssue, total, position, relatedPosts = [] }: PostViewProps) {
   const renderedHtml = issue?.body_html || ''
   const { containerRef, previewProps } = usePostImagePreview(renderedHtml)
   const tocResult = useToc(renderedHtml)
@@ -237,6 +241,22 @@ export default function PostView({ issue, prevIssue, nextIssue, total, position 
           <ArticleCard>
             <MarkdownBody className='markdown-body' dangerouslySetInnerHTML={{ __html: tocResult.html }} />
           </ArticleCard>
+
+          {relatedPosts.length > 0 && (
+            <RelatedPostsSection aria-labelledby='related-posts-title'>
+              <h2 id='related-posts-title'>相关文章</h2>
+              <ul>
+                {relatedPosts.map((post) => (
+                  <li key={post.number}>
+                    <RelatedPostLink href={buildPostUrl(post.number, post.title)}>
+                      <RelatedPostTitle>{post.title}</RelatedPostTitle>
+                      <RelatedPostLabels>{post.sharedLabels.slice(0, 2).join(' · ')}</RelatedPostLabels>
+                    </RelatedPostLink>
+                  </li>
+                ))}
+              </ul>
+            </RelatedPostsSection>
+          )}
 
           <ImagePreview {...previewProps} />
 

--- a/packages/wuh.site.next/app/post/PostView.types.ts
+++ b/packages/wuh.site.next/app/post/PostView.types.ts
@@ -1,3 +1,5 @@
+import type { RelatedPost } from '../lib/related-posts'
+
 export type IssueLabel = {
   name: string
   color?: string | null
@@ -45,4 +47,5 @@ export type PostViewProps = {
   nextIssue: AdjacentIssue | null
   total?: number
   position?: number
+  relatedPosts?: RelatedPost[]
 }

--- a/packages/wuh.site.next/app/post/[number]/page.tsx
+++ b/packages/wuh.site.next/app/post/[number]/page.tsx
@@ -7,6 +7,7 @@ import { buildPostUrl, isCanonicalPostPath } from '../../lib/slug'
 import type { ContentItem, AdjacentPost } from '@wuh.site/shared-contracts'
 import PostView from '../PostView'
 import type { Issue } from '../PostView.types'
+import { selectRelatedPosts, type RelatedPostCandidate } from '../../lib/related-posts'
 import JsonLd from '../../components/JsonLd'
 import { createArticleStructuredData, createBreadcrumbStructuredData } from '../../lib/structured-data'
 
@@ -54,6 +55,33 @@ const mapContentToIssue = (item: ContentItem): Issue => ({
     keywords: item.metadata.keywords || null,
   } : null,
 })
+
+
+const mapContentToRelatedPost = (item: ContentItem): RelatedPostCandidate => ({
+  number: item.number,
+  title: item.title,
+  labels: item.labels,
+  updatedAt: item.updatedAtGitHub || item.createdAtGitHub,
+  summary: item.metadata?.summary || null,
+})
+
+async function getRelatedPosts(issue: Issue) {
+  const labels = Array.from(new Set(issue.labels.map((label) => label.name.trim()).filter(Boolean))).slice(0, 3)
+  if (labels.length === 0) return []
+
+  const responses = await Promise.all(
+    labels.map((label) => contentService.getPosts.server({
+      query: { labels: [label], limit: '10', state: 'open' },
+      revalidate: 3600,
+    })),
+  )
+  const candidates = responses.flatMap(({ data, error }) => {
+    if (error || !data) return []
+    return (((data as any).data || []) as ContentItem[]).map(mapContentToRelatedPost)
+  })
+
+  return selectRelatedPosts({ number: issue.number, labels }, candidates)
+}
 
 type IssueData = {
   issue: Issue | null
@@ -133,6 +161,7 @@ export default async function Page({ params }: { params: Promise<{ number: strin
     permanentRedirect(buildPostUrl(issue.number, issue.title))
   }
 
+  const relatedPosts = await getRelatedPosts(issue)
   const url = `${SITE_URL}${buildPostUrl(issue.number, issue.title)}`
   const articleJsonLd = createArticleStructuredData({
     url,
@@ -155,7 +184,7 @@ export default async function Page({ params }: { params: Promise<{ number: strin
     <>
       <JsonLd data={articleJsonLd} />
       <JsonLd data={breadcrumbJsonLd} />
-      <PostView issue={issue} prevIssue={prevIssue} nextIssue={nextIssue} total={total} position={position} />
+      <PostView issue={issue} prevIssue={prevIssue} nextIssue={nextIssue} total={total} position={position} relatedPosts={relatedPosts} />
     </>
   )
 }

--- a/packages/wuh.site.next/app/post/styles/index.ts
+++ b/packages/wuh.site.next/app/post/styles/index.ts
@@ -1,6 +1,6 @@
 export { Container, ContentGrid, MainColumn } from './post-layout'
 export { TocAside, TocCard, TocTitle, TocList, TocItemLink, TocMobile } from './post-toc'
-export { ArticleCard, RedundantInfoCard, ShareInfoCard, ShareCardInner, MarkdownBody, StatusEmpty, CommentPlaceholder } from './post-article'
+export { ArticleCard, RedundantInfoCard, ShareInfoCard, ShareCardInner, MarkdownBody, StatusEmpty, CommentPlaceholder, RelatedPostsSection, RelatedPostLink, RelatedPostTitle, RelatedPostLabels } from './post-article'
 export { Toolbar } from './post-toolbar'
 export { Header, Title, MetaRow, TagGroup, CoverImage, PostLead, AuthorRow, AuthorAvatar, AuthorInfo, Summary, OrnamentDivider, BreadcrumbNav, BreadcrumbLink, BreadcrumbCurrent } from './post-header'
 export { FloatingButtonGroup, FloatingButton, LikeButton } from './post-floating'

--- a/packages/wuh.site.next/app/post/styles/post-article.ts
+++ b/packages/wuh.site.next/app/post/styles/post-article.ts
@@ -104,3 +104,78 @@ export const StatusEmpty = styled(Empty)`
 export const CommentPlaceholder = styled(Empty)`
   margin-top: var(--space-md);
 `
+
+
+export const RelatedPostsSection = styled.section`
+  margin-top: var(--space-xl);
+  padding: 24px;
+  border: 1px solid color-mix(in oklab, var(--primary-color) 14%, var(--normal-300));
+  border-radius: var(--radius-card);
+  background: color-mix(in oklab, var(--background-100) 96%, var(--primary-color) 4%);
+
+  h2 {
+    margin: 0 0 var(--space-md);
+    color: var(--text-primary);
+    font-family: var(--font-serif);
+    font-size: var(--font-size-lg);
+  }
+
+  ul {
+    display: grid;
+    gap: 10px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  @media (max-width: 640px) {
+    padding: 18px;
+  }
+`
+
+export const RelatedPostLink = styled.a`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+  padding: 12px 14px;
+  color: var(--text-primary);
+  text-decoration: none;
+  border: 1px solid color-mix(in oklab, var(--normal-300) 45%, transparent);
+  border-radius: 10px;
+  background: var(--background-100);
+  transition: border-color 0.2s ease, transform 0.2s ease;
+
+  &:hover {
+    border-color: color-mix(in oklab, var(--primary-color) 48%, transparent);
+    transform: translateY(-1px);
+  }
+
+  &:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--primary-color) 36%, transparent);
+    outline-offset: 2px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+
+    &:hover {
+      transform: none;
+    }
+  }
+`
+
+export const RelatedPostTitle = styled.span`
+  min-width: 0;
+  overflow: hidden;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`
+
+export const RelatedPostLabels = styled.span`
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  white-space: nowrap;
+`

--- a/packages/wuh.site.next/test/related-posts.test.mjs
+++ b/packages/wuh.site.next/test/related-posts.test.mjs
@@ -1,0 +1,32 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { selectRelatedPosts } from '../app/lib/related-posts.ts'
+
+test('selects unique related posts by shared labels and recency', () => {
+  const posts = selectRelatedPosts(
+    { number: 10, labels: ['Next.js', 'SEO'] },
+    [
+      { number: 10, title: '当前文章', labels: ['Next.js'], updatedAt: '2026-07-22' },
+      { number: 11, title: '两个标签', labels: ['Next.js', 'SEO'], updatedAt: '2026-07-20' },
+      { number: 12, title: '一个标签较新', labels: ['SEO'], updatedAt: '2026-07-23' },
+      { number: 12, title: '重复数据', labels: ['SEO'], updatedAt: '2026-07-19' },
+      { number: 13, title: '无关文章', labels: ['NestJS'], updatedAt: '2026-07-24' },
+    ],
+  )
+
+  assert.deepEqual(posts.map((post) => post.number), [11, 12])
+})
+
+test('caps related posts at three items', () => {
+  const posts = selectRelatedPosts(
+    { number: 10, labels: ['Next.js'] },
+    [11, 12, 13, 14].map((number) => ({
+      number,
+      title: `文章 ${number}`,
+      labels: ['Next.js'],
+      updatedAt: `2026-07-${number}`,
+    })),
+  )
+
+  assert.equal(posts.length, 3)
+})

--- a/packages/wuh.site.next/test/seo-p12-related-posts.test.mjs
+++ b/packages/wuh.site.next/test/seo-p12-related-posts.test.mjs
@@ -1,0 +1,26 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const testDir = dirname(fileURLToPath(import.meta.url))
+const appRoot = resolve(testDir, '..')
+const postPageSource = await readFile(resolve(appRoot, 'app/post/[number]/page.tsx'), 'utf8')
+const postViewSource = await readFile(resolve(appRoot, 'app/post/PostView.tsx'), 'utf8')
+
+test('post page fetches candidates by labels with cached parallel requests', () => {
+  assert.match(postPageSource, /async function getRelatedPosts/)
+  assert.match(postPageSource, /Promise\.all/)
+  assert.match(postPageSource, /labels: \[label\]/)
+  assert.match(postPageSource, /revalidate:\s*3600/)
+  assert.match(postPageSource, /selectRelatedPosts/)
+  assert.match(postPageSource, /relatedPosts=\{relatedPosts\}/)
+})
+
+test('post view renders related posts only when candidates exist', () => {
+  assert.match(postViewSource, /relatedPosts\.length > 0/)
+  assert.match(postViewSource, /RelatedPostsSection aria-labelledby='related-posts-title'/)
+  assert.match(postViewSource, /id='related-posts-title'>相关文章/)
+  assert.match(postViewSource, /buildPostUrl\(post.number, post.title\)/)
+})


### PR DESCRIPTION
## 变更概述

实现 #238（关联 #233）的相关文章与语义内部链接能力：

- 按当前文章最多三个标签并发获取已发布候选内容。
- 排除当前文章，以共享标签数、更新时间、文章编号为稳定排序依据。
- 按文章编号去重并限制为最多三篇。
- 相关文章链接统一使用 canonical `/post/{number}-{slug}` URL。
- 文章没有标签、候选请求失败或无关联内容时不渲染空模块。
- 文章正文之后新增语义化“相关文章” section。

## 验证

- 6 个前端测试文件、28 个测试用例通过（分文件串行执行）。
- Oxlint 通过。
- `git diff --check` 通过。
- TypeScript CLI 在隔离克隆环境触发 SIGSEGV，需通过 CI/完整依赖环境复验。

## 关联 Issue

Refs #238

> 本 PR 以 `codex/seo-p1` 为 base，需在 #237 合并后再合并。
