### PR TITLE
feat: add SEO topic pages

### DIFF
--- a/docs/superpowers/plans/2026-07-25-seo-p13-topic-pages.md
+++ b/docs/superpowers/plans/2026-07-25-seo-p13-topic-pages.md
@@ -1,0 +1,46 @@
+# SEO P1.3 Topic Pages Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 新增稳定可索引的 `/topics/[label]` 主题聚合页，并让博客列表标签链接进入主题页。
+
+**Architecture:** 通过纯工具函数集中处理 topic URL 编解码；新增 server route `app/topics/[label]/page.tsx` 获取单标签文章并输出 SEO metadata；复用博客样式渲染主题页内容；博客列表中的标签包裹为内部链接。
+
+**Tech Stack:** Next.js App Router、TypeScript、Node test runner、styled-components。
+
+---
+
+## 文件结构
+
+- Create: `packages/wuh.site.next/app/lib/topic-url.ts` — 主题 URL 编解码。
+- Create: `packages/wuh.site.next/app/topics/[label]/page.tsx` — 可索引主题页。
+- Modify: `packages/wuh.site.next/app/blog/BlogListView.tsx` — 标签链接到主题页。
+- Modify: `packages/wuh.site.next/app/blog/styles/index.ts` — 标签链接样式。
+- Create: `packages/wuh.site.next/test/topic-url.test.mjs` — topic URL 工具测试。
+- Create: `packages/wuh.site.next/test/seo-p13-topic-pages.test.mjs` — 页面和入口回归测试。
+
+## Task 1: Topic URL 工具
+
+- [ ] 写失败测试：`buildTopicUrl('Next.js SEO') === '/topics/Next.js%20SEO'`，`decodeTopicParam('Next.js%20SEO') === 'Next.js SEO'`。
+- [ ] 实现 `buildTopicUrl` 和 `decodeTopicParam`。
+- [ ] 重跑测试确认通过。
+
+## Task 2: 主题页路由
+
+- [ ] 写失败测试：断言 `app/topics/[label]/page.tsx` 包含 `generateMetadata`、`alternates.canonical`、`contentService.getPosts.server`、`buildPostUrl`、`decodeTopicParam`。
+- [ ] 实现路由：按单标签获取 open posts，metadata 使用 `/topics/${encoded}` canonical，渲染主题说明、数量和文章列表。
+- [ ] 重跑测试确认通过。
+
+## Task 3: 博客标签入口
+
+- [ ] 写失败测试：断言 `BlogListView` 使用 `buildTopicUrl(label.name)` 包裹 `Tag`。
+- [ ] 将文章列表里的 Tag 包裹为 `PostTagLink`。
+- [ ] 增加样式，避免破坏 Tag 外观。
+- [ ] 重跑测试确认通过。
+
+## Task 4: 验证与提交
+
+- [ ] 运行全部 `packages/wuh.site.next/test/*.test.mjs`。
+- [ ] 运行 oxlint 与 `git diff --check`。
+- [ ] 尝试 TypeScript，记录当前隔离环境 SIGSEGV 如仍复现。
+- [ ] 提交、推送 `codex/seo-p13`，创建 base `codex/seo-p12` 的链式 PR 并更新 #240。

--- a/packages/wuh.site.next/app/blog/BlogListView.tsx
+++ b/packages/wuh.site.next/app/blog/BlogListView.tsx
@@ -9,6 +9,7 @@ import TitleWithTooltip from './components/TitleWithTooltip'
 import BackHomeLink from '@/app/components/BackHomeLink'
 import type { ContentLabelSummary, PostListItem } from '@wuh.site/shared-contracts'
 import { buildPostUrl } from '../lib/slug'
+import { buildTopicUrl } from '../lib/topic-url'
 import { formatShortDate } from '../lib/date'
 import { buildBlogUrl, formatFilterOptionLabel, getFilterSummaryLabel, toggleLabel } from './blog-filter-utils'
 import * as S from './styles'
@@ -98,14 +99,18 @@ export default function BlogListView({ posts, pagination, activeLabels, availabl
               <S.YearGroup key={year}>
                 <S.YearLabel>{year}</S.YearLabel>
                 {yearPosts.map(post => (
-                  <S.PostRow key={post.id} href={buildPostUrl(post.number, post.title)}>
+                  <S.PostRow key={post.id}>
                     <S.InkDot />
-                    <TitleWithTooltip text={post.title} />
+                    <S.PostTitleLink href={buildPostUrl(post.number, post.title)}>
+                      <TitleWithTooltip text={post.title} />
+                    </S.PostTitleLink>
                     <S.IssueNumber>#{post.number}</S.IssueNumber>
                     {post.labels?.length > 0 && (
                       <S.PostTags>
                         {post.labels.slice(0, TAG_DISPLAY_LIMIT).map(label => (
-                          <Tag key={`${post.id}-${label.name}`} label={label.name} color={label.color} />
+                          <S.PostTagLink key={`${post.id}-${label.name}`} href={buildTopicUrl(label.name)} aria-label={`查看 ${label.name} 主题文章`}>
+                            <Tag label={label.name} color={label.color} />
+                          </S.PostTagLink>
                         ))}
                       </S.PostTags>
                     )}

--- a/packages/wuh.site.next/app/blog/styles/index.ts
+++ b/packages/wuh.site.next/app/blog/styles/index.ts
@@ -140,7 +140,6 @@ export const FilterOption = styled(Link)<{ $active: boolean }>`
   &:hover {
     color: var(--primary-color);
     background: color-mix(in oklab, var(--accent-color) 16%, var(--background-100, #fff));
-    text-decoration: none;
   }
 `
 
@@ -199,13 +198,12 @@ export const YearLabel = styled.div`
   }
 `
 
-export const PostRow = styled(Link)`
+export const PostRow = styled.div`
   display: flex;
   align-items: center;
   gap: var(--space-sm);
   padding: var(--space-xs) 8px;
   border-radius: 6px;
-  text-decoration: none;
   color: inherit;
   transition: background-color var(--transition-fast) ease, padding-left var(--transition-fast) ease;
 
@@ -234,6 +232,38 @@ export const IssueNumber = styled.span`
   flex-shrink: 0;
   min-width: 36px;
   text-align: right;
+`
+
+export const PostTitleLink = styled(Link)`
+  min-width: 0;
+  color: inherit;
+  text-decoration: none;
+
+  &:hover {
+    color: var(--primary-color);
+    text-decoration: none;
+  }
+
+  &:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--primary-color) 36%, transparent);
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+`
+
+export const PostTagLink = styled(Link)`
+  display: inline-flex;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: none;
+  }
+
+  &:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--primary-color) 36%, transparent);
+    outline-offset: 2px;
+    border-radius: 6px;
+  }
 `
 
 export const PostTags = styled.span`

--- a/packages/wuh.site.next/app/lib/topic-url.ts
+++ b/packages/wuh.site.next/app/lib/topic-url.ts
@@ -1,0 +1,11 @@
+export function normalizeTopicLabel(label: string): string {
+  return label.trim().replace(/\s+/g, ' ')
+}
+
+export function buildTopicUrl(label: string): string {
+  return `/topics/${encodeURIComponent(normalizeTopicLabel(label))}`
+}
+
+export function decodeTopicParam(param: string): string {
+  return normalizeTopicLabel(decodeURIComponent(param))
+}

--- a/packages/wuh.site.next/app/topics/[label]/page.tsx
+++ b/packages/wuh.site.next/app/topics/[label]/page.tsx
@@ -1,0 +1,123 @@
+import type { Metadata } from 'next'
+import Empty from '@wuh.site/components/empty'
+import Tag from '@wuh.site/components/tag'
+import { IconBookOpen } from '@wuh.site/components/icons'
+import { contentService } from '@wuh.site/shared-contracts/endpoints'
+import type { ContentItem, PostListItem } from '@wuh.site/shared-contracts'
+import BackHomeLink from '@/app/components/BackHomeLink'
+import { buildPostUrl } from '@/app/lib/slug'
+import { buildTopicUrl, decodeTopicParam } from '@/app/lib/topic-url'
+import { formatShortDate } from '@/app/lib/date'
+import * as S from '@/app/blog/styles'
+
+const SITE_URL = 'https://wuh.site'
+const PER_PAGE = 20
+
+type TopicPageParams = {
+  label: string
+}
+
+const mapContentToPost = (item: ContentItem): PostListItem => ({
+  id: item.externalId,
+  number: item.number,
+  title: item.title,
+  html_url: `https://github.com/${item.repo}/issues/${item.number}`,
+  views: item.viewCount ?? 0,
+  created_at: item.createdAtGitHub || '',
+  labels: item.labels.map((label) => ({ name: label })),
+})
+
+async function getTopicPosts(label: string) {
+  const { data, error } = await contentService.getPosts.server({
+    query: { page: '1', limit: String(PER_PAGE), state: 'open', labels: [label] },
+    revalidate: 600,
+  })
+
+  if (error || !data) {
+    return { posts: [] as PostListItem[], total: 0 }
+  }
+
+  const result = data as any
+  return {
+    posts: (result.data || []).map(mapContentToPost) as PostListItem[],
+    total: result.pagination?.total ?? 0,
+  }
+}
+
+export async function generateMetadata({ params }: { params: Promise<TopicPageParams> }): Promise<Metadata> {
+  const { label: rawLabel } = await params
+  const label = decodeTopicParam(rawLabel)
+  const title = `${label} 相关文章`
+  const description = `阅读 wuh.site 中与「${label}」相关的文章。`
+  const url = `${SITE_URL}${buildTopicUrl(label)}`
+
+  return {
+    title,
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: 'wuh.site',
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary',
+      title,
+      description,
+    },
+  }
+}
+
+export default async function TopicPage({ params }: { params: Promise<TopicPageParams> }) {
+  const { label: rawLabel } = await params
+  const label = decodeTopicParam(rawLabel)
+  const { posts, total } = await getTopicPosts(label)
+
+  return (
+    <S.Root>
+      <S.Main>
+        <BackHomeLink />
+        <S.Header>
+          <S.TitleGroup>
+            <S.Title>#{label}</S.Title>
+            <S.Subtitle>共 {total} 篇相关文章，按发布时间展示最新内容。</S.Subtitle>
+          </S.TitleGroup>
+        </S.Header>
+
+        {posts.length === 0 ? (
+          <Empty icon={<IconBookOpen />} title='暂无相关文章' description={`还没有与「${label}」相关的文章`} actions={[{ label: '返回博客', href: '/blog' }]} />
+        ) : (
+          <S.Timeline>
+            <S.YearGroup>
+              <S.YearLabel>Topic</S.YearLabel>
+              {posts.map((post) => (
+                <S.PostRow key={post.id}>
+                  <S.InkDot />
+                  <S.PostTitleLink href={buildPostUrl(post.number, post.title)}>
+                    <span>{post.title}</span>
+                  </S.PostTitleLink>
+                  {post.labels?.length > 0 && (
+                    <S.PostTags>
+                      {post.labels.slice(0, 3).map((item) => (
+                        <S.PostTagLink key={`${post.id}-${item.name}`} href={buildTopicUrl(item.name)} aria-label={`查看 ${item.name} 主题文章`}>
+                          <Tag label={item.name} color={item.color} />
+                        </S.PostTagLink>
+                      ))}
+                    </S.PostTags>
+                  )}
+                  <S.PostMeta>
+                    <span>{formatShortDate(post.created_at)}</span>
+                    <S.MetaDot />
+                    <span>{post.views} 浏览</span>
+                  </S.PostMeta>
+                </S.PostRow>
+              ))}
+            </S.YearGroup>
+          </S.Timeline>
+        )}
+      </S.Main>
+    </S.Root>
+  )
+}

--- a/packages/wuh.site.next/test/seo-p13-topic-pages.test.mjs
+++ b/packages/wuh.site.next/test/seo-p13-topic-pages.test.mjs
@@ -1,0 +1,35 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const testDir = dirname(fileURLToPath(import.meta.url))
+const appRoot = resolve(testDir, '..')
+const topicPagePath = resolve(appRoot, 'app/topics/[label]/page.tsx')
+const blogListViewSource = await readFile(resolve(appRoot, 'app/blog/BlogListView.tsx'), 'utf8')
+const blogStylesSource = await readFile(resolve(appRoot, 'app/blog/styles/index.ts'), 'utf8')
+let topicPageSource = ''
+try {
+  topicPageSource = await readFile(topicPagePath, 'utf8')
+} catch {}
+
+test('topic page exposes canonical metadata and fetches posts by decoded label', () => {
+  assert.match(topicPageSource, /generateMetadata/)
+  assert.match(topicPageSource, /alternates:\s*\{\s*canonical:/)
+  assert.match(topicPageSource, /contentService\.getPosts\.server/)
+  assert.match(topicPageSource, /decodeTopicParam/)
+  assert.match(topicPageSource, /buildPostUrl/)
+})
+
+test('blog post tags link to stable topic pages', () => {
+  assert.match(blogListViewSource, /buildTopicUrl\(label\.name\)/)
+  assert.match(blogListViewSource, /PostTagLink/)
+})
+
+
+test('blog rows avoid nested anchors by using separate title and topic links', () => {
+  assert.match(blogStylesSource, /export const PostRow = styled\.div/)
+  assert.match(blogListViewSource, /PostTitleLink href=\{buildPostUrl\(post.number, post.title\)\}/)
+  assert.match(blogListViewSource, /PostTagLink key=\{`\$\{post.id\}-\$\{label.name\}`\} href=\{buildTopicUrl\(label.name\)\}/)
+})

--- a/packages/wuh.site.next/test/topic-url.test.mjs
+++ b/packages/wuh.site.next/test/topic-url.test.mjs
@@ -1,0 +1,13 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { buildTopicUrl, decodeTopicParam } from '../app/lib/topic-url.ts'
+
+test('builds stable topic URLs with encoded labels', () => {
+  assert.equal(buildTopicUrl('Next.js SEO'), '/topics/Next.js%20SEO')
+  assert.equal(buildTopicUrl('  中文 标签  '), '/topics/%E4%B8%AD%E6%96%87%20%E6%A0%87%E7%AD%BE')
+})
+
+test('decodes topic route parameters into labels', () => {
+  assert.equal(decodeTopicParam('Next.js%20SEO'), 'Next.js SEO')
+  assert.equal(decodeTopicParam('%E4%B8%AD%E6%96%87%20%E6%A0%87%E7%AD%BE'), '中文 标签')
+})


### PR DESCRIPTION
## 变更概述

实现 #240（关联 #233）的稳定主题聚合页：

- 新增 `/topics/[label]` 动态主题页。
- 主题页按单个标签获取 open posts，并输出文章列表。
- 主题页提供独立 title、description、canonical、Open Graph 和 Twitter metadata。
- 主题页文章链接使用 canonical `/post/{number}-{slug}` URL。
- 新增 topic URL 编解码工具，集中处理 label canonical path。
- 博客列表标签入口改为 `/topics/[label]` 稳定内部链接。
- 修正博客列表行结构，避免在整行文章链接中嵌套标签链接。

## 验证

- 8 个前端测试文件、33 个测试用例通过（分文件串行执行）。
- Oxlint 通过。
- `git diff --check` 通过。
- TypeScript CLI 在隔离克隆环境触发 SIGSEGV，需通过 CI/完整依赖环境复验。

## 关联 Issue

Refs #240

> 本 PR 以 `codex/seo-p12` 为 base，需在 #239 合并后再合并。
