### PR TITLE
feat: add topic sitemap and blog noindex

### DIFF
--- a/docs/superpowers/plans/2026-07-25-seo-p14-sitemap-noindex.md
+++ b/docs/superpowers/plans/2026-07-25-seo-p14-sitemap-noindex.md
@@ -1,0 +1,41 @@
+# SEO P1.4 Sitemap and Noindex Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把 `/topics/[label]` 纳入 sitemap 主动发现，并让旧 `/blog?labels=` 筛选页 noindex/follow。
+
+**Architecture:** `app/lib/sitemap.ts` 新增 topic sitemap entry builder；`app/sitemap.ts` 拉取 label summaries 并追加 topic entries；`app/blog/page.tsx` 改为 `generateMetadata`，根据 searchParams 决定 robots/canonical。
+
+**Tech Stack:** Next.js Metadata API、Next MetadataRoute.Sitemap、Node test runner。
+
+---
+
+## 文件结构
+
+- Modify: `packages/wuh.site.next/app/lib/sitemap.ts` — topic sitemap entry builder。
+- Modify: `packages/wuh.site.next/app/sitemap.ts` — 拉取 labels 并输出 topic sitemap entries。
+- Modify: `packages/wuh.site.next/app/blog/page.tsx` — 动态 metadata：query label noindex/follow。
+- Create: `packages/wuh.site.next/test/seo-p14-sitemap-noindex.test.mjs` — 回归测试。
+
+## Task 1: topic sitemap builder
+
+- [ ] 测试 `buildTopicSitemapEntry({ name: 'Next.js' }).url === 'https://wuh.site/topics/Next.js'`。
+- [ ] 实现 builder，使用 `buildTopicUrl`。
+
+## Task 2: sitemap 拉取 labels
+
+- [ ] 源码测试断言 `app/sitemap.ts` 使用 `getLabels.server`、`buildTopicSitemapEntry`，且不拼接 query URL。
+- [ ] 实现 `getOpenLabels()`，异常显式 throw。
+- [ ] 输出 static + topic + post routes。
+
+## Task 3: blog query noindex
+
+- [ ] 测试断言 `app/blog/page.tsx` 使用 `generateMetadata`，并包含 active labels 判断、`index: false`、`follow: true`。
+- [ ] 将静态 `metadata` 改为 `generateMetadata`。
+- [ ] 无 labels：保持 index/follow；page > 1 canonical 使用 `/blog?page=N`；有 labels：canonical `/blog` 且 noindex/follow。
+
+## Task 4: verify, commit, PR
+
+- [ ] 运行全部前端测试、Oxlint、diff check。
+- [ ] 尝试 TypeScript，记录隔离环境 SIGSEGV。
+- [ ] 提交、推送 `codex/seo-p14`，创建 base `codex/seo-p13` 的链式 PR，更新 #243。

--- a/packages/wuh.site.next/app/blog/page.tsx
+++ b/packages/wuh.site.next/app/blog/page.tsx
@@ -6,23 +6,37 @@ import { toLabelParams } from './blog-filter-utils'
 
 const SITE_URL = 'https://wuh.site'
 
-export const metadata: Metadata = {
-  title: '博客',
-  description: '收录 GitHub Issues 中的全部博客文章',
-  robots: { index: true, follow: true },
-  alternates: { canonical: `${SITE_URL}/blog` },
-  openGraph: {
-    title: 'wuh.site 博客',
-    description: '收录 GitHub Issues 中的全部博客文章',
-    url: `${SITE_URL}/blog`,
-    siteName: 'wuh.site',
-    type: 'website',
-  },
-  twitter: {
-    card: 'summary',
-    title: 'wuh.site 博客',
-    description: '收录 GitHub Issues 中的全部博客文章',
-  },
+export async function generateMetadata({ searchParams }: { searchParams?: BlogSearchParams | Promise<BlogSearchParams> }): Promise<Metadata> {
+  const resolvedSearchParams = await searchParams
+  const activeLabels = toLabelParams(resolvedSearchParams?.labels)
+  const hasActiveLabels = activeLabels.length > 0
+  const currentPage = toPageNumber(resolvedSearchParams?.page)
+  const canonicalPath = currentPage > 1 && !hasActiveLabels ? `/blog?page=${currentPage}` : '/blog'
+  const description = hasActiveLabels
+    ? `筛选 wuh.site 中与「${activeLabels.join('、')}」相关的博客文章。`
+    : '收录 GitHub Issues 中的全部博客文章'
+  const robots = hasActiveLabels
+    ? { index: false, follow: true }
+    : { index: true, follow: true }
+
+  return {
+    title: hasActiveLabels ? '博客筛选' : '博客',
+    description,
+    robots,
+    alternates: { canonical: hasActiveLabels ? `${SITE_URL}/blog` : `${SITE_URL}${canonicalPath}` },
+    openGraph: {
+      title: hasActiveLabels ? 'wuh.site 博客筛选' : 'wuh.site 博客',
+      description,
+      url: hasActiveLabels ? `${SITE_URL}/blog` : `${SITE_URL}${canonicalPath}`,
+      siteName: 'wuh.site',
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary',
+      title: hasActiveLabels ? 'wuh.site 博客筛选' : 'wuh.site 博客',
+      description,
+    },
+  }
 }
 
 const PER_PAGE = 10

--- a/packages/wuh.site.next/app/lib/sitemap.ts
+++ b/packages/wuh.site.next/app/lib/sitemap.ts
@@ -1,7 +1,12 @@
 import type { MetadataRoute } from 'next'
 import { buildPostUrl } from './slug.ts'
+import { buildTopicUrl } from './topic-url.ts'
 
 export const SITE_URL = 'https://wuh.site'
+
+export type SitemapTopic = {
+  name: string
+}
 
 export type SitemapPost = {
   number: number
@@ -26,5 +31,14 @@ export function buildPostSitemapEntry(post: SitemapPost): MetadataRoute.Sitemap[
     ...(lastModified ? { lastModified: new Date(lastModified) } : {}),
     changeFrequency: 'weekly',
     priority: 0.6,
+  }
+}
+
+
+export function buildTopicSitemapEntry(topic: SitemapTopic): MetadataRoute.Sitemap[number] {
+  return {
+    url: `${SITE_URL}${buildTopicUrl(topic.name)}`,
+    changeFrequency: 'weekly',
+    priority: 0.5,
   }
 }

--- a/packages/wuh.site.next/app/sitemap.ts
+++ b/packages/wuh.site.next/app/sitemap.ts
@@ -3,16 +3,34 @@ import { contentService } from '@wuh.site/shared-contracts/endpoints'
 import {
   buildPostSitemapEntry,
   buildStaticSitemapRoutes,
+  buildTopicSitemapEntry,
   type SitemapPost,
+  type SitemapTopic,
 } from './lib/sitemap'
 
 const SITEMAP_PAGE_SIZE = 100
+
+type SitemapLabelsResponse = SitemapTopic[]
 
 type SitemapPostsResponse = {
   data: SitemapPost[]
   pagination?: {
     hasNextPage?: boolean
   }
+}
+
+
+async function getOpenLabels(): Promise<SitemapTopic[]> {
+  const { data, error } = await contentService.getLabels.server({
+    query: { state: 'open' },
+    revalidate: 3600,
+  })
+
+  if (error || !data) {
+    throw new Error('Failed to load sitemap labels')
+  }
+
+  return (data as SitemapLabelsResponse).filter((label) => label.name?.trim())
 }
 
 async function getPublishedPosts(): Promise<SitemapPost[]> {
@@ -44,9 +62,10 @@ async function getPublishedPosts(): Promise<SitemapPost[]> {
 }
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const posts = await getPublishedPosts()
+  const [labels, posts] = await Promise.all([getOpenLabels(), getPublishedPosts()])
   return [
     ...buildStaticSitemapRoutes(),
+    ...labels.map(buildTopicSitemapEntry),
     ...posts.map(buildPostSitemapEntry),
   ]
 }

--- a/packages/wuh.site.next/test/seo-p14-sitemap-noindex.test.mjs
+++ b/packages/wuh.site.next/test/seo-p14-sitemap-noindex.test.mjs
@@ -1,0 +1,31 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { buildTopicSitemapEntry } from '../app/lib/sitemap.ts'
+
+const testDir = dirname(fileURLToPath(import.meta.url))
+const appRoot = resolve(testDir, '..')
+const sitemapSource = await readFile(resolve(appRoot, 'app/sitemap.ts'), 'utf8')
+const blogPageSource = await readFile(resolve(appRoot, 'app/blog/page.tsx'), 'utf8')
+
+test('builds topic sitemap entries using canonical topic URLs', () => {
+  const entry = buildTopicSitemapEntry({ name: 'Next.js SEO' })
+  assert.equal(entry.url, 'https://wuh.site/topics/Next.js%20SEO')
+  assert.equal(entry.changeFrequency, 'weekly')
+})
+
+test('sitemap appends topic entries from open labels without query URLs', () => {
+  assert.match(sitemapSource, /getLabels\.server/)
+  assert.match(sitemapSource, /buildTopicSitemapEntry/)
+  assert.doesNotMatch(sitemapSource, /labels=/)
+})
+
+test('blog metadata noindexes label query pages but leaves base blog indexable', () => {
+  assert.match(blogPageSource, /generateMetadata/)
+  assert.match(blogPageSource, /activeLabels\.length > 0/)
+  assert.match(blogPageSource, /index:\s*false/)
+  assert.match(blogPageSource, /follow:\s*true/)
+  assert.match(blogPageSource, /canonical:\s*hasActiveLabels \? `\$\{SITE_URL\}\/blog`/)
+})


### PR DESCRIPTION
## 变更概述

实现 #243（关联 #233）的主题页 sitemap 与旧筛选页 noindex 策略：

- Sitemap 新增 open labels 对应的 `/topics/[label]` URL。
- Topic sitemap entry 使用 `buildTopicUrl`，与主题页编码规则一致。
- Sitemap 继续不输出任意 query 筛选 URL。
- `/blog` 基础页保持 `index, follow`。
- `/blog?page=N` 保留分页 canonical URL。
- `/blog?labels=...` 改为 `noindex, follow`，canonical 指回 `/blog`，避免与 `/topics/[label]` 竞争索引。
- 新增 sitemap/noindex 回归测试。

## 验证

- 9 个前端测试文件、36 个测试用例通过（分文件串行执行）。
- Oxlint 通过。
- `git diff --check` 通过。
- TypeScript CLI 在隔离克隆环境触发 SIGSEGV，需通过 CI/完整依赖环境复验。

## 关联 Issue

Refs #243

> 本 PR 以 `codex/seo-p13` 为 base，需在 #242 合并后再合并。
