### PR TITLE
fix: 修复 Console 根 tsconfig 类型检查配置

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,14 +2,25 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true,
-    "lib": ["dom", "dom.iterable", "ES2021"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "ES2021"
+    ],
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "strictNullChecks": false,
     "strictPropertyInitialization": false,
     "noImplicitAny": false,
     "isolatedModules": false,
-    "useUnknownInCatchVariables": false
+    "useUnknownInCatchVariables": false,
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "packages/wuh.site.console/src/*"
+      ]
+    }
   },
   "include": [
     "packages/*/src/**/*.ts",


### PR DESCRIPTION
## Summary

- 修复根 `tsconfig.json` 未支持 Console `.tsx` / `@/*` alias 导致的 CI 类型检查错误
- 增加：`jsx: react-jsx`
- 增加：`baseUrl: .` 和 `@/* -> packages/wuh.site.console/src/*`

## Verification

- `tsconfig.json` JSON parse passed locally
- `git diff --check` passed locally
- Local TypeScript Program still intermittently segfaults in this worktree, but the CI-reported missing JSX/alias configuration is now present in root tsconfig.

Related: #234 / #227
