### PR TITLE
feat: link article labels to topics

### DIFF
--- a/docs/superpowers/plans/2026-07-25-seo-p15-article-topic-links.md
+++ b/docs/superpowers/plans/2026-07-25-seo-p15-article-topic-links.md
@@ -1,0 +1,26 @@
+# SEO P1.5 Article Topic Links Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 将文章详情页标签链接改为站内主题页链接，并让 Alert 内部链接不再强制新窗口打开。
+
+**Architecture:** PostView 使用 `buildTopicUrl` 生成标签 href；Alert 组件根据 href 是否外部决定 target/rel，保留外部链接安全属性。
+
+**Tech Stack:** React、Next.js、styled-components、Node source regression tests。
+
+---
+
+## 文件结构
+
+- Modify: `packages/wuh.site.next/app/post/PostView.tsx` — 标签 href 指向 `/topics/[label]`。
+- Modify: `packages/components/alert/index.tsx` — 标签链接 target/rel 按内部/外部区分。
+- Create: `packages/wuh.site.next/test/seo-p15-article-topic-links.test.mjs` — 回归测试。
+
+## Steps
+
+- [ ] 写失败测试：PostView 使用 `buildTopicUrl(label.name)`，不再构造 GitHub issue label query。
+- [ ] 写失败测试：Alert 具有 `isExternalHref`，LabelLink target/rel 根据外部链接条件设置。
+- [ ] 实现 PostView 标签内链化。
+- [ ] 实现 Alert 内外链 target/rel 策略。
+- [ ] 跑全部前端测试、Oxlint、diff check，尝试 TypeScript 并记录 SIGSEGV。
+- [ ] 提交、推送并创建 base `codex/seo-p14` 的链式 PR，更新 #246。

--- a/packages/components/alert/index.tsx
+++ b/packages/components/alert/index.tsx
@@ -61,6 +61,9 @@ export interface AlertProps extends Omit<React.HTMLAttributes<HTMLElement>, 'tit
   onClose?: () => void
 }
 
+
+const isExternalHref = (href: string) => /^https?:\/\//i.test(href)
+
 const pad = (value: number) => value.toString().padStart(2, '0')
 
 const formatDateTimeToSecond = (value?: DateInput | null) => {
@@ -219,7 +222,7 @@ const Alert = React.forwardRef<HTMLElement, AlertProps>(function Alert(props, re
             </MetaLabel>
             <LabelList aria-label='文档标签'>
               {labels.map((label) => (
-                <LabelLink key={`${label.name}-${label.href}`} href={label.href} target='_blank' rel='noopener noreferrer' title={label.name}>
+                <LabelLink key={`${label.name}-${label.href}`} href={label.href} target={isExternalHref(label.href) ? '_blank' : undefined} rel={isExternalHref(label.href) ? 'noopener noreferrer' : undefined} title={label.name}>
                   <Tag label={label.name} color={label.color} />
                 </LabelLink>
               ))}

--- a/packages/wuh.site.next/app/post/PostView.tsx
+++ b/packages/wuh.site.next/app/post/PostView.tsx
@@ -17,6 +17,7 @@ import FloatingActions from './components/FloatingActions'
 import { openSharePopup, openWechatShareWindow } from '../share-utils'
 
 import { buildPostUrl } from '@/app/lib/slug'
+import { buildTopicUrl } from '@/app/lib/topic-url'
 import {
   ArticleCard,
   BreadcrumbCurrent,
@@ -53,11 +54,6 @@ const copyToClipboard = async (text: string): Promise<boolean> => {
   } catch {
     return false
   }
-}
-
-const createLabelHref = (labelName: string) => {
-  const query = encodeURIComponent(`is:issue label:"${labelName}"`)
-  return `${BLOG_PROJECT_URL}/issues?q=${query}`
 }
 
 const toGithubWebUrl = (repositoryUrl?: string | null) => {
@@ -108,7 +104,7 @@ const createAlertLabels = (issue: Issue): AlertLabel[] =>
   issue.labels.map((label) => ({
     name: label.name,
     color: label.color,
-    href: createLabelHref(label.name),
+    href: buildTopicUrl(label.name),
   }))
 
 const createShareItems = (issue: Issue): ShareItem[] => {

--- a/packages/wuh.site.next/test/seo-p15-article-topic-links.test.mjs
+++ b/packages/wuh.site.next/test/seo-p15-article-topic-links.test.mjs
@@ -1,0 +1,23 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const testDir = dirname(fileURLToPath(import.meta.url))
+const appRoot = resolve(testDir, '..')
+const repoRoot = resolve(appRoot, '../..')
+const postViewSource = await readFile(resolve(appRoot, 'app/post/PostView.tsx'), 'utf8')
+const alertSource = await readFile(resolve(repoRoot, 'packages/components/alert/index.tsx'), 'utf8')
+
+test('post alert labels link to internal topic pages', () => {
+  assert.match(postViewSource, /buildTopicUrl/)
+  assert.match(postViewSource, /href:\s*buildTopicUrl\(label\.name\)/)
+  assert.doesNotMatch(postViewSource, /is:issue label:/)
+})
+
+test('alert label links only open external hrefs in a new tab', () => {
+  assert.match(alertSource, /const isExternalHref/)
+  assert.match(alertSource, /target=\{isExternalHref\(label\.href\) \? '_blank' : undefined\}/)
+  assert.match(alertSource, /rel=\{isExternalHref\(label\.href\) \? 'noopener noreferrer' : undefined\}/)
+})


### PR DESCRIPTION
## 变更概述

实现 #246（关联 #233）的文章标签站内主题页链接：

- 文章详情页“所属标签”链接从 GitHub Issue search 改为 `/topics/[label]`。
- 标签 URL 复用 `buildTopicUrl`，与主题页和 sitemap 编码规则一致。
- Alert 组件对内部 href 不再强制 `target="_blank"` 和 `rel="noopener noreferrer"`。
- 外部 href 仍保留 `_blank` 与 `noopener noreferrer` 安全策略。
- 新增回归测试覆盖 PostView 标签 href 和 Alert 内外链 target/rel 策略。

## 验证

- 10 个前端测试文件、38 个测试用例通过（分文件串行执行；首次批量运行偶发 SIGSEGV 后逐文件重跑通过）。
- Oxlint 通过。
- TypeScript 检查通过。
- `git diff --check` 通过。

## 关联 Issue

Refs #246

> 本 PR 以 `codex/seo-p14` 为 base，需在 #244 合并后再合并。
