### PR TITLE
feat: add SEO archive page

### DIFF
--- a/docs/superpowers/plans/2026-07-25-seo-p16-archive-page.md
+++ b/docs/superpowers/plans/2026-07-25-seo-p16-archive-page.md
@@ -1,0 +1,29 @@
+# SEO P1.6 Archive Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 新增 `/archive` 博客归档页，并将其纳入 sitemap 和博客页入口。
+
+**Architecture:** 归档页作为 server component 分页读取所有 open posts，按年份分组展示。复用 blog 样式与 canonical post/topic URL 工具，避免新增复杂 UI 或后端接口。
+
+**Tech Stack:** Next.js App Router、Metadata API、Node test runner、styled-components。
+
+---
+
+## 文件结构
+
+- Create: `packages/wuh.site.next/app/archive/page.tsx` — 归档页面。
+- Modify: `packages/wuh.site.next/app/lib/sitemap.ts` — 增加 `/archive` 静态 sitemap 路由。
+- Modify: `packages/wuh.site.next/app/blog/BlogListView.tsx` — 增加归档入口。
+- Create: `packages/wuh.site.next/test/seo-p16-archive-page.test.mjs` — 回归测试。
+
+## Steps
+
+- [ ] 写失败测试：`buildStaticSitemapRoutes` 包含 `/archive`。
+- [ ] 写失败测试：`archive/page.tsx` 包含 metadata、canonical、分页读取、`buildPostUrl` 与 `buildTopicUrl`。
+- [ ] 写失败测试：博客页头部包含 `/archive` 入口。
+- [ ] 实现 `/archive` 页面。
+- [ ] 更新 sitemap 静态路由。
+- [ ] 更新 BlogListView header actions。
+- [ ] 跑全部测试、Oxlint、TypeScript、diff check。
+- [ ] 提交、推送并创建 base `codex/seo-p15` 的链式 PR，更新 #248。

--- a/packages/wuh.site.next/app/archive/page.tsx
+++ b/packages/wuh.site.next/app/archive/page.tsx
@@ -1,0 +1,137 @@
+import type { Metadata } from 'next'
+import Empty from '@wuh.site/components/empty'
+import Tag from '@wuh.site/components/tag'
+import { IconBookOpen } from '@wuh.site/components/icons'
+import { contentService } from '@wuh.site/shared-contracts/endpoints'
+import type { ContentItem, PostListItem } from '@wuh.site/shared-contracts'
+import BackHomeLink from '@/app/components/BackHomeLink'
+import { buildPostUrl } from '@/app/lib/slug'
+import { buildTopicUrl } from '@/app/lib/topic-url'
+import { formatShortDate } from '@/app/lib/date'
+import * as S from '@/app/blog/styles'
+
+const SITE_URL = 'https://wuh.site'
+const ARCHIVE_PAGE_SIZE = 100
+
+export const metadata: Metadata = {
+  title: '归档',
+  description: '按年份浏览 wuh.site 的全部博客文章。',
+  robots: { index: true, follow: true },
+  alternates: { canonical: `${SITE_URL}/archive` },
+  openGraph: {
+    title: 'wuh.site 文章归档',
+    description: '按年份浏览 wuh.site 的全部博客文章。',
+    url: `${SITE_URL}/archive`,
+    siteName: 'wuh.site',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'wuh.site 文章归档',
+    description: '按年份浏览 wuh.site 的全部博客文章。',
+  },
+}
+
+const mapContentToPost = (item: ContentItem): PostListItem => ({
+  id: item.externalId,
+  number: item.number,
+  title: item.title,
+  html_url: `https://github.com/${item.repo}/issues/${item.number}`,
+  views: item.viewCount ?? 0,
+  created_at: item.createdAtGitHub || '',
+  labels: item.labels.map((label) => ({ name: label })),
+})
+
+function groupPostsByYear(posts: PostListItem[]) {
+  const map = new Map<number, PostListItem[]>()
+  posts.forEach((post) => {
+    const year = new Date(post.created_at).getFullYear()
+    const list = map.get(year)
+    if (list) {
+      list.push(post)
+    } else {
+      map.set(year, [post])
+    }
+  })
+  return Array.from(map.entries()).sort((a, b) => b[0] - a[0])
+}
+
+async function getArchivePosts() {
+  const posts: PostListItem[] = []
+  let page = 1
+
+  while (true) {
+    const { data, error } = await contentService.getPosts.server({
+      query: { page: String(page), limit: String(ARCHIVE_PAGE_SIZE), state: 'open' },
+      revalidate: 3600,
+    })
+
+    if (error || !data) {
+      throw new Error(`Failed to load archive posts on page ${page}`)
+    }
+
+    const result = data as any
+    posts.push(...(((result.data || []) as ContentItem[]).map(mapContentToPost)))
+
+    if (!result.pagination?.hasNextPage) break
+    page += 1
+  }
+
+  return posts
+}
+
+export default async function ArchivePage() {
+  const posts = await getArchivePosts()
+  const yearGroups = groupPostsByYear(posts)
+
+  return (
+    <S.Root>
+      <S.Main>
+        <S.Header>
+          <S.TitleGroup>
+            <S.Title>文章归档</S.Title>
+            <S.Subtitle>按年份浏览全部 {posts.length} 篇博客文章</S.Subtitle>
+          </S.TitleGroup>
+          <S.HeaderActions>
+            <BackHomeLink href='/blog' label='返回博客' />
+          </S.HeaderActions>
+        </S.Header>
+
+        {posts.length === 0 ? (
+          <Empty icon={<IconBookOpen />} title='暂无归档' description='暂时没有可展示的博客文章' actions={[{ label: '返回博客', href: '/blog' }]} />
+        ) : (
+          <S.Timeline>
+            {yearGroups.map(([year, yearPosts]) => (
+              <S.YearGroup key={year}>
+                <S.YearLabel>{year}</S.YearLabel>
+                {yearPosts.map((post) => (
+                  <S.PostRow key={post.id}>
+                    <S.InkDot />
+                    <S.PostTitleLink href={buildPostUrl(post.number, post.title)}>
+                      <span>{post.title}</span>
+                    </S.PostTitleLink>
+                    <S.IssueNumber>#{post.number}</S.IssueNumber>
+                    {post.labels?.length > 0 && (
+                      <S.PostTags>
+                        {post.labels.slice(0, 3).map((label) => (
+                          <S.PostTagLink key={`${post.id}-${label.name}`} href={buildTopicUrl(label.name)} aria-label={`查看 ${label.name} 主题文章`}>
+                            <Tag label={label.name} color={label.color} />
+                          </S.PostTagLink>
+                        ))}
+                      </S.PostTags>
+                    )}
+                    <S.PostMeta>
+                      <span>{formatShortDate(post.created_at)}</span>
+                      <S.MetaDot />
+                      <span>{post.views} 浏览</span>
+                    </S.PostMeta>
+                  </S.PostRow>
+                ))}
+              </S.YearGroup>
+            ))}
+          </S.Timeline>
+        )}
+      </S.Main>
+    </S.Root>
+  )
+}

--- a/packages/wuh.site.next/app/blog/BlogListView.tsx
+++ b/packages/wuh.site.next/app/blog/BlogListView.tsx
@@ -6,6 +6,7 @@ import Pagination from '@wuh.site/components/pagination'
 import Empty from '@wuh.site/components/empty'
 import { IconBookOpen } from '@wuh.site/components/icons'
 import TitleWithTooltip from './components/TitleWithTooltip'
+import Button from '@wuh.site/components/button'
 import BackHomeLink from '@/app/components/BackHomeLink'
 import type { ContentLabelSummary, PostListItem } from '@wuh.site/shared-contracts'
 import { buildPostUrl } from '../lib/slug'
@@ -54,6 +55,7 @@ export default function BlogListView({ posts, pagination, activeLabels, availabl
             <S.Subtitle>收录 GitHub Issues 中的全部博客文章</S.Subtitle>
           </S.TitleGroup>
           <S.HeaderActions>
+            <Button href='/archive' variant='text' color='secondary' size='small'>归档</Button>
             <BackHomeLink href='/' />
           </S.HeaderActions>
         </S.Header>

--- a/packages/wuh.site.next/app/lib/sitemap.ts
+++ b/packages/wuh.site.next/app/lib/sitemap.ts
@@ -19,6 +19,7 @@ export function buildStaticSitemapRoutes(): MetadataRoute.Sitemap {
   return [
     { url: SITE_URL, changeFrequency: 'daily', priority: 1.0 },
     { url: `${SITE_URL}/blog`, changeFrequency: 'daily', priority: 0.8 },
+    { url: `${SITE_URL}/archive`, changeFrequency: 'daily', priority: 0.7 },
     { url: `${SITE_URL}/about`, changeFrequency: 'monthly', priority: 0.5 },
   ]
 }

--- a/packages/wuh.site.next/test/seo-p16-archive-page.test.mjs
+++ b/packages/wuh.site.next/test/seo-p16-archive-page.test.mjs
@@ -1,0 +1,34 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { buildStaticSitemapRoutes } from '../app/lib/sitemap.ts'
+
+const testDir = dirname(fileURLToPath(import.meta.url))
+const appRoot = resolve(testDir, '..')
+const archivePagePath = resolve(appRoot, 'app/archive/page.tsx')
+const blogListViewSource = await readFile(resolve(appRoot, 'app/blog/BlogListView.tsx'), 'utf8')
+let archivePageSource = ''
+try {
+  archivePageSource = await readFile(archivePagePath, 'utf8')
+} catch {}
+
+test('static sitemap includes the archive page', () => {
+  const urls = buildStaticSitemapRoutes().map((route) => route.url)
+  assert.equal(urls.includes('https://wuh.site/archive'), true)
+})
+
+test('archive page exposes canonical metadata and canonical post/topic links', () => {
+  assert.match(archivePageSource, /export const metadata/)
+  assert.match(archivePageSource, /canonical:\s*`?\$\{SITE_URL\}\/archive`?/)
+  assert.match(archivePageSource, /while \(true\)/)
+  assert.match(archivePageSource, /contentService\.getPosts\.server/)
+  assert.match(archivePageSource, /buildPostUrl\(post.number, post.title\)/)
+  assert.match(archivePageSource, /buildTopicUrl\(label.name\)/)
+})
+
+test('blog page header links to archive', () => {
+  assert.match(blogListViewSource, /href='\/archive'/)
+  assert.match(blogListViewSource, /归档/)
+})


### PR DESCRIPTION
## 变更概述

实现 #248（关联 #233）的博客归档页：

- 新增 `/archive` 归档页面，按年份展示全部 open posts。
- 归档页分页读取所有文章，避免一次性 `limit=9999`。
- 归档页提供独立 metadata、canonical、Open Graph 和 Twitter 信息。
- 归档页文章链接统一使用 canonical `/post/{number}-{slug}` URL。
- 归档页标签链接统一使用 `/topics/[label]`。
- `/archive` 加入 sitemap 静态路由。
- `/blog` 头部新增“归档”入口。
- 新增归档页回归测试。

## 验证

- 11 个前端测试文件、41 个测试用例通过（分文件串行执行）。
- Oxlint 通过。
- TypeScript 检查通过。
- `git diff --check` 通过。

## 关联 Issue

Refs #248

> 本 PR 以 `codex/seo-p15` 为 base，需在 #247 合并后再合并。
