### PR TITLE
feat: add collection page structured data

### DIFF
--- a/docs/superpowers/plans/2026-07-25-seo-p17-collection-pages.md
+++ b/docs/superpowers/plans/2026-07-25-seo-p17-collection-pages.md
@@ -1,0 +1,27 @@
+# SEO P1.7 CollectionPage Structured Data Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为主题页和归档页输出 CollectionPage / ItemList JSON-LD。
+
+**Architecture:** 扩展现有 `structured-data.ts` 纯 builder，接收集合 URL、名称、描述和 canonical 条目。主题页与归档页在服务端获得 posts 后调用 builder 并通过现有 JsonLd 组件输出。
+
+**Tech Stack:** Next.js、Schema.org JSON-LD、TypeScript、Node test runner。
+
+---
+
+## 文件结构
+
+- Modify: `packages/wuh.site.next/app/lib/structured-data.ts` — CollectionPage builder。
+- Modify: `packages/wuh.site.next/app/topics/[label]/page.tsx` — 输出 topic collection JSON-LD。
+- Modify: `packages/wuh.site.next/app/archive/page.tsx` — 输出 archive collection JSON-LD。
+- Create: `packages/wuh.site.next/test/seo-p17-collection-pages.test.mjs` — builder 与页面回归测试。
+
+## Steps
+
+- [ ] 写失败测试：builder 返回 `CollectionPage`、`ItemList`、递增 position、canonical item URL。
+- [ ] 实现 `createCollectionPageStructuredData`。
+- [ ] 写失败测试：topic/archive 页面调用 builder 和 JsonLd。
+- [ ] 在两页输出对应 JSON-LD。
+- [ ] 跑全部测试、Oxlint、TypeScript、diff check。
+- [ ] 提交、推送，创建 base `codex/seo-p16` 的链式 PR 并更新 #250。

--- a/packages/wuh.site.next/app/archive/page.tsx
+++ b/packages/wuh.site.next/app/archive/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import JsonLd from '@/app/components/JsonLd'
 import Empty from '@wuh.site/components/empty'
 import Tag from '@wuh.site/components/tag'
 import { IconBookOpen } from '@wuh.site/components/icons'
@@ -8,6 +9,7 @@ import BackHomeLink from '@/app/components/BackHomeLink'
 import { buildPostUrl } from '@/app/lib/slug'
 import { buildTopicUrl } from '@/app/lib/topic-url'
 import { formatShortDate } from '@/app/lib/date'
+import { createCollectionPageStructuredData } from '@/app/lib/structured-data'
 import * as S from '@/app/blog/styles'
 
 const SITE_URL = 'https://wuh.site'
@@ -83,9 +85,20 @@ async function getArchivePosts() {
 export default async function ArchivePage() {
   const posts = await getArchivePosts()
   const yearGroups = groupPostsByYear(posts)
+  const collectionJsonLd = createCollectionPageStructuredData({
+    url: `${SITE_URL}/archive`,
+    name: 'wuh.site 文章归档',
+    description: '按年份浏览 wuh.site 的全部博客文章。',
+    items: posts.map((post) => ({
+      name: post.title,
+      url: `${SITE_URL}${buildPostUrl(post.number, post.title)}`,
+    })),
+  })
 
   return (
-    <S.Root>
+    <>
+      <JsonLd data={collectionJsonLd} />
+      <S.Root>
       <S.Main>
         <S.Header>
           <S.TitleGroup>
@@ -132,6 +145,7 @@ export default async function ArchivePage() {
           </S.Timeline>
         )}
       </S.Main>
-    </S.Root>
+      </S.Root>
+    </>
   )
 }

--- a/packages/wuh.site.next/app/lib/structured-data.ts
+++ b/packages/wuh.site.next/app/lib/structured-data.ts
@@ -114,3 +114,45 @@ export function createBreadcrumbStructuredData(items: BreadcrumbItem[]): JsonLdR
     })),
   }
 }
+
+type CollectionPageItem = {
+  name: string
+  url: string
+}
+
+type CollectionPageStructuredDataInput = {
+  url: string
+  name: string
+  description: string
+  items: CollectionPageItem[]
+}
+
+export function createCollectionPageStructuredData(input: CollectionPageStructuredDataInput): JsonLdRecord {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': input.url,
+    },
+    name: input.name,
+    description: input.description,
+    url: input.url,
+    inLanguage: 'zh-CN',
+    isPartOf: {
+      '@type': 'Blog',
+      name: 'wuh.site',
+      url: `${SITE_URL}/blog`,
+    },
+    mainEntity: {
+      '@type': 'ItemList',
+      numberOfItems: input.items.length,
+      itemListElement: input.items.map((item, index) => ({
+        '@type': 'ListItem',
+        position: index + 1,
+        name: item.name,
+        item: item.url,
+      })),
+    },
+  }
+}

--- a/packages/wuh.site.next/app/topics/[label]/page.tsx
+++ b/packages/wuh.site.next/app/topics/[label]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import JsonLd from '@/app/components/JsonLd'
 import Empty from '@wuh.site/components/empty'
 import Tag from '@wuh.site/components/tag'
 import { IconBookOpen } from '@wuh.site/components/icons'
@@ -8,6 +9,7 @@ import BackHomeLink from '@/app/components/BackHomeLink'
 import { buildPostUrl } from '@/app/lib/slug'
 import { buildTopicUrl, decodeTopicParam } from '@/app/lib/topic-url'
 import { formatShortDate } from '@/app/lib/date'
+import { createCollectionPageStructuredData } from '@/app/lib/structured-data'
 import * as S from '@/app/blog/styles'
 
 const SITE_URL = 'https://wuh.site'
@@ -74,9 +76,21 @@ export default async function TopicPage({ params }: { params: Promise<TopicPageP
   const { label: rawLabel } = await params
   const label = decodeTopicParam(rawLabel)
   const { posts, total } = await getTopicPosts(label)
+  const url = `${SITE_URL}${buildTopicUrl(label)}`
+  const collectionJsonLd = createCollectionPageStructuredData({
+    url,
+    name: `${label} 相关文章`,
+    description: `阅读 wuh.site 中与「${label}」相关的文章。`,
+    items: posts.map((post) => ({
+      name: post.title,
+      url: `${SITE_URL}${buildPostUrl(post.number, post.title)}`,
+    })),
+  })
 
   return (
-    <S.Root>
+    <>
+      <JsonLd data={collectionJsonLd} />
+      <S.Root>
       <S.Main>
         <BackHomeLink />
         <S.Header>
@@ -118,6 +132,7 @@ export default async function TopicPage({ params }: { params: Promise<TopicPageP
           </S.Timeline>
         )}
       </S.Main>
-    </S.Root>
+      </S.Root>
+    </>
   )
 }

--- a/packages/wuh.site.next/test/seo-p17-collection-pages.test.mjs
+++ b/packages/wuh.site.next/test/seo-p17-collection-pages.test.mjs
@@ -1,0 +1,36 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { createCollectionPageStructuredData } from '../app/lib/structured-data.ts'
+
+const testDir = dirname(fileURLToPath(import.meta.url))
+const appRoot = resolve(testDir, '..')
+const topicPageSource = await readFile(resolve(appRoot, 'app/topics/[label]/page.tsx'), 'utf8')
+const archivePageSource = await readFile(resolve(appRoot, 'app/archive/page.tsx'), 'utf8')
+
+test('creates a CollectionPage with canonical item list entries', () => {
+  const data = createCollectionPageStructuredData({
+    url: 'https://wuh.site/topics/Next.js',
+    name: 'Next.js 相关文章',
+    description: 'Next.js 主题文章。',
+    items: [
+      { name: '文章一', url: 'https://wuh.site/post/1-one' },
+      { name: '文章二', url: 'https://wuh.site/post/2-two' },
+    ],
+  })
+
+  assert.equal(data['@type'], 'CollectionPage')
+  assert.equal(data.mainEntity['@type'], 'ItemList')
+  assert.equal(data.mainEntity.numberOfItems, 2)
+  assert.deepEqual(data.mainEntity.itemListElement.map((item) => item.position), [1, 2])
+  assert.equal(data.mainEntity.itemListElement[1].item, 'https://wuh.site/post/2-two')
+})
+
+test('topic and archive pages render collection structured data', () => {
+  assert.match(topicPageSource, /createCollectionPageStructuredData/)
+  assert.match(topicPageSource, /<JsonLd data=\{collectionJsonLd\}/)
+  assert.match(archivePageSource, /createCollectionPageStructuredData/)
+  assert.match(archivePageSource, /<JsonLd data=\{collectionJsonLd\}/)
+})


### PR DESCRIPTION
## 变更概述

实现 #250（关联 #233）的 CollectionPage 结构化数据：

- structured-data builder 新增 `createCollectionPageStructuredData`。
- `/topics/[label]` 输出 `CollectionPage` + `ItemList` JSON-LD。
- `/archive` 输出 `CollectionPage` + `ItemList` JSON-LD。
- ItemList 条目 URL 使用 canonical `/post/{number}-{slug}`。
- 空集合仍输出有效的 ItemList 结构。
- 新增 builder 与页面输出回归测试。

## 验证

- 12 个前端测试文件、43 个测试用例通过（分文件串行执行）。
- Oxlint 通过。
- TypeScript 检查通过。
- `git diff --check` 通过。

## 关联 Issue

Refs #250

> 本 PR 以 `codex/seo-p16` 为 base，需在 #249 合并后再合并。
