### PR TITLE
fix(next): accept encoded post paths

### DIFF
--- a/packages/wuh.site.next/app/lib/slug.ts
+++ b/packages/wuh.site.next/app/lib/slug.ts
@@ -10,6 +10,14 @@ export function buildPostUrl(number: number | string, title: string): string {
   return `/post/${number}-${toSlug(title)}`
 }
 
+function decodePathname(pathname: string): string {
+  try {
+    return decodeURIComponent(pathname)
+  } catch {
+    return pathname
+  }
+}
+
 export function isCanonicalPostPath(pathname: string, number: number | string, title: string): boolean {
-  return pathname === `${number}-${toSlug(title)}`
+  return decodePathname(pathname) === `${number}-${toSlug(title)}`
 }

--- a/packages/wuh.site.next/test/seo-p0.test.mjs
+++ b/packages/wuh.site.next/test/seo-p0.test.mjs
@@ -24,6 +24,7 @@ test('accepts only the current canonical post path', () => {
   assert.equal(isCanonicalPostPath('123-Next.js-15-SEO', 123, 'Next.js #15 / SEO'), true)
   assert.equal(isCanonicalPostPath('123', 123, 'Next.js #15 / SEO'), false)
   assert.equal(isCanonicalPostPath('123-old-title', 123, 'Next.js #15 / SEO'), false)
+  assert.equal(isCanonicalPostPath('165-%E5%86%8D%E8%AF%BB%E3%80%8A%E5%9D%90%E5%BF%98%E6%AD%8C%E3%80%8B', 165, '再读《坐忘歌》'), true)
 })
 
 test('post SEO rendering does not depend on request cookies and uses ISR', () => {


### PR DESCRIPTION
## Root cause
- Canonical URL validation compared the encoded route parameter from a browser request with an unencoded Chinese slug.
- The mismatch triggered `permanentRedirect` on every detail-page render, causing a client redirect loop and a blank page.

## Fix
- Decode the route parameter before canonical comparison.
- Preserve redirects for genuinely stale or invalid slugs.

## Verification
- `node --experimental-strip-types --test packages/wuh.site.next/test/seo-p0.test.mjs` (9/9)