### PR TITLE
chore: 归档后台 Console 并增强 sitemap 日志 (#227, #233)

### DIFF
--- a/openspec/changes/archive/2026-07-19-P-admin-console/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-19-P-admin-console/.openspec.yaml
@@ -10,7 +10,7 @@ change:
   id: 2026-07-19-P-admin-console
   title: 独立后台 Console 与 GitHub 认证只读权限
   type: feature
-  status: committed
+  status: archived
   createdAt: 2026-07-19T07:45:47Z
   issue: https://github.com/stack-wuh/x.wuh.site/issues/227
 
@@ -221,7 +221,7 @@ discuss:
     rollback: Console package 可独立下线；后端新增后台路由不影响公开站点，如 OAuth 异常可临时关闭 Console 部署。
 
 apply:
-  status: completed
+  status: ready
   generatedFrom:
     - proposal
     - discuss
@@ -232,7 +232,7 @@ apply:
   workflow:
     - id: backend-contracts-user-role
       title: 后端权限契约与用户角色固定
-      status: completed
+      status: pending
       dependsOn: []
       files:
         - packages/shared-contracts/src/admin.dto.ts
@@ -249,12 +249,11 @@ apply:
       requiredInputs: []
       attempts: 0
       maxAttempts: 2
-      evidence:
-        - Implemented in worktree and covered by targeted tests/build where applicable.
+      evidence: []
       failure: null
     - id: backend-auth-oauth-me
       title: GitHub OAuth 与当前用户接口
-      status: completed
+      status: pending
       dependsOn:
         - backend-contracts-user-role
       files:
@@ -283,12 +282,11 @@ apply:
           supplied: false
       attempts: 0
       maxAttempts: 2
-      evidence:
-        - Implemented in worktree and covered by targeted tests/build where applicable.
+      evidence: []
       failure: null
     - id: backend-root-guard
       title: RootGuard 与后台写权限拦截
-      status: completed
+      status: pending
       dependsOn:
         - backend-auth-oauth-me
       files:
@@ -305,12 +303,11 @@ apply:
       requiredInputs: []
       attempts: 0
       maxAttempts: 2
-      evidence:
-        - Implemented in worktree and covered by targeted tests/build where applicable.
+      evidence: []
       failure: null
     - id: admin-content-api
       title: 博客后台管理 API
-      status: completed
+      status: pending
       dependsOn:
         - backend-root-guard
       files:
@@ -328,12 +325,11 @@ apply:
       requiredInputs: []
       attempts: 0
       maxAttempts: 2
-      evidence:
-        - Implemented in worktree and covered by targeted tests/build where applicable.
+      evidence: []
       failure: null
     - id: admin-guestbook-api
       title: 留言板后台管理 API
-      status: completed
+      status: pending
       dependsOn:
         - backend-root-guard
       files:
@@ -350,12 +346,11 @@ apply:
       requiredInputs: []
       attempts: 0
       maxAttempts: 2
-      evidence:
-        - Implemented in worktree and covered by targeted tests/build where applicable.
+      evidence: []
       failure: null
     - id: admin-post-comments-api
       title: 博客评论审核后台 API
-      status: completed
+      status: pending
       dependsOn:
         - backend-root-guard
       files:
@@ -373,12 +368,11 @@ apply:
       requiredInputs: []
       attempts: 0
       maxAttempts: 2
-      evidence:
-        - Implemented in worktree and covered by targeted tests/build where applicable.
+      evidence: []
       failure: null
     - id: admin-overview-users-api
       title: 后台概览与用户只读 API
-      status: completed
+      status: pending
       dependsOn:
         - backend-root-guard
       files:
@@ -394,12 +388,11 @@ apply:
       requiredInputs: []
       attempts: 0
       maxAttempts: 2
-      evidence:
-        - Implemented in worktree and covered by targeted tests/build where applicable.
+      evidence: []
       failure: null
     - id: console-vite-scaffold
       title: 创建 Vite React Console package
-      status: completed
+      status: pending
       dependsOn: []
       files:
         - packages/wuh.site.console/package.json
@@ -417,12 +410,11 @@ apply:
       requiredInputs: []
       attempts: 0
       maxAttempts: 2
-      evidence:
-        - Implemented in worktree and covered by targeted tests/build where applicable.
+      evidence: []
       failure: null
     - id: console-auth-shell
       title: Console 认证与权限框架
-      status: completed
+      status: pending
       dependsOn:
         - console-vite-scaffold
         - backend-auth-oauth-me
@@ -441,12 +433,11 @@ apply:
       requiredInputs: []
       attempts: 0
       maxAttempts: 2
-      evidence:
-        - Implemented in worktree and covered by targeted tests/build where applicable.
+      evidence: []
       failure: null
     - id: console-content-pages
       title: Console 博客管理页面
-      status: completed
+      status: pending
       dependsOn:
         - console-auth-shell
         - admin-content-api
@@ -462,12 +453,11 @@ apply:
       requiredInputs: []
       attempts: 0
       maxAttempts: 2
-      evidence:
-        - Implemented in worktree and covered by targeted tests/build where applicable.
+      evidence: []
       failure: null
     - id: console-guestbook-comments-pages
       title: Console 留言板与评论管理页面
-      status: completed
+      status: pending
       dependsOn:
         - console-auth-shell
         - admin-guestbook-api
@@ -485,12 +475,11 @@ apply:
       requiredInputs: []
       attempts: 0
       maxAttempts: 2
-      evidence:
-        - Implemented in worktree and covered by targeted tests/build where applicable.
+      evidence: []
       failure: null
     - id: console-dashboard-users-pages
       title: Console 用户与概览页面
-      status: completed
+      status: pending
       dependsOn:
         - console-auth-shell
         - admin-overview-users-api
@@ -505,12 +494,11 @@ apply:
       requiredInputs: []
       attempts: 0
       maxAttempts: 2
-      evidence:
-        - Implemented in worktree and covered by targeted tests/build where applicable.
+      evidence: []
       failure: null
     - id: integration-env-docs
       title: 集成配置与环境示例
-      status: completed
+      status: pending
       dependsOn:
         - backend-auth-oauth-me
         - console-vite-scaffold
@@ -530,12 +518,11 @@ apply:
           supplied: false
       attempts: 0
       maxAttempts: 2
-      evidence:
-        - Implemented in worktree and covered by targeted tests/build where applicable.
+      evidence: []
       failure: null
     - id: full-verification
       title: 全量验证
-      status: skipped
+      status: pending
       dependsOn:
         - console-content-pages
         - console-guestbook-comments-pages
@@ -556,14 +543,9 @@ apply:
         - key: REAL_GITHUB_OAUTH_TEST_ACCOUNT
           description: 若要做真实 OAuth E2E，需要一个非 stack-wuh GitHub 账号验证 reader；单元测试可先 mock。
           supplied: false
-      attempts: 1
+      attempts: 0
       maxAttempts: 2
-      evidence:
-        - pnpm install --lockfile-only --ignore-scripts passed and updated pnpm-lock.yaml for @wuh.site/console.
-        - UserService/AuthService/RootGuard/AdminController targeted Jest specs passed individually with Node v20.20.2 and --detectOpenHandles.
-        - 后端目标单测：UserService/AuthService/RootGuard/AdminController 均已单独通过。
-        - git diff --check 通过。
-        - 按用户要求停止调用 build 指令，Console build 不再作为当前 apply 阻塞项。
+      evidence: []
       failure: null
   repairWorkflow: []
   checkpoint:
@@ -571,165 +553,31 @@ apply:
     updatedAt: null
 
 review:
-  status: passed
-  verification:
-    - id: artifact-contracts
-      command: validate-artifact-contract proposal/design/tasks/spec
-      result: passed
-      summary: proposal.md, design.md, tasks.md, specs/admin-console/spec.md all passed template contract validation.
-      at: 2026-07-23T14:55:30Z
-    - id: diff-check
-      command: git diff --check
-      result: passed
-      summary: No whitespace errors or conflict markers in current diff.
-      at: 2026-07-23T14:55:30Z
-    - id: yaml-parse
-      command: ruby -e 'require "yaml"; YAML.load_file("pnpm-lock.yaml"); YAML.load_file("openspec/changes/2026-07-19-P-admin-console/.openspec.yaml")'
-      result: passed
-      summary: pnpm-lock.yaml and Agent Loop control YAML parse successfully.
-      at: 2026-07-23T14:55:30Z
-    - id: user-role-tests
-      command: node jest --runTestsByPath packages/wuh.site.nest/src/modules/user/user.service.spec.ts
-      result: passed
-      summary: UserService fixes stack-wuh as only root and forces non-root GitHub users to reader during upsert.
-      at: 2026-07-23T14:55:30Z
-    - id: auth-controller-tests
-      command: node jest --runTestsByPath packages/wuh.site.nest/src/modules/auth/auth.controller.spec.ts
-      result: passed
-      summary: OAuth state cookie is generated, callback state mismatch is rejected, login clears OAuth cookies and redirects safely.
-      at: 2026-07-23T14:55:30Z
-    - id: auth-service-tests
-      command: node jest --runTestsByPath packages/wuh.site.nest/src/modules/auth/auth.service.spec.ts
-      result: passed
-      summary: AuthService builds GitHub OAuth URL, signs root token for stack-wuh and reader token for other users with permissions.
-      at: 2026-07-23T14:55:30Z
-    - id: jwt-auth-guard-tests
-      command: node jest --runTestsByPath packages/wuh.site.nest/src/modules/auth/jwt-auth.guard.spec.ts
-      result: passed
-      summary: JwtAuthGuard normalizes stale non-stack-wuh root claims to reader and reads bearer/cookie tokens.
-      at: 2026-07-23T14:55:30Z
-    - id: root-guard-tests
-      command: node jest --runTestsByPath packages/wuh.site.nest/src/modules/auth/root.guard.spec.ts
-      result: passed
-      summary: RootGuard allows only stack-wuh and rejects stale root claims from other logins.
-      at: 2026-07-23T14:55:30Z
-    - id: admin-controller-tests
-      command: node jest --runTestsByPath packages/wuh.site.nest/src/modules/admin/admin.controller.spec.ts
-      result: passed
-      summary: AdminController user role downgrade, blog list/detail, guestbook list, post comment filter and approve delegation covered.
-      at: 2026-07-23T14:55:30Z
-    - id: cors-origin-tests
-      command: node jest --runTestsByPath packages/wuh.site.nest/src/common/utils/cors-origin.util.spec.ts
-      result: passed
-      summary: CORS origin parser supports wildcard, comma-separated main/console origins and blank trimming.
-      at: 2026-07-23T14:55:30Z
-    - id: console-build
-      command: pnpm --filter @wuh.site/console run build
-      result: unavailable
-      summary: Build verification intentionally not repeated after user requested not to call build; earlier attempts were dominated by local Node/Vite native exit 139.
-      at: 2026-07-23T14:55:30Z
-  findings:
-    - id: R-001
-      severity: blocker
-      file: packages/wuh.site.nest/src/modules/auth/auth.controller.ts
-      message: GitHub OAuth callback lacked server-generated state cookie validation, allowing CSRF-style callback confusion.
-      status: fixed
-    - id: R-002
-      severity: blocker
-      file: packages/wuh.site.nest/src/modules/auth/root.guard.ts
-      message: RootGuard previously trusted role=root in token payload; non-stack-wuh stale root tokens could pass server write guard.
-      status: fixed
-    - id: R-003
-      severity: warning
-      file: packages/wuh.site.nest/src/modules/auth/jwt-auth.guard.ts
-      message: /auth/me could expose stale root permissions from old token payloads; guard now normalizes non-stack-wuh users to reader.
-      status: fixed
-    - id: R-004
-      severity: warning
-      file: packages/wuh.site.nest/src/main.ts
-      message: CORS_ORIGIN comma-separated env value was not parsed as multiple origins, which would block separate Console origin in development/deploy.
-      status: fixed
-    - id: W-001
-      severity: warning
-      file: packages/wuh.site.console
-      message: Console build and real browser/OAuth E2E were not completed in this review because user requested to stop invoking build; final UI/build verification remains pending before release.
-      status: accepted
-  summary: Review found and fixed OAuth state validation, stale root-token server guard, /auth/me normalization, and multi-origin CORS issues. User explicitly accepted deferring Console build/browser OAuth E2E until release verification.
+  status: pending
+  verification: []
+  findings: []
+  summary: null
 
 archive:
-  status: completed
-  archivedAt: 2026-07-23T14:58:00Z
-  movedAt: 2026-07-23T14:57:00Z
-  specSync:
-    - domain: admin-console
-      source: openspec/changes/archive/2026-07-19-P-admin-console/specs/admin-console/spec.md
-      target: openspec/specs/admin-console/spec.md
-      result: created
-      evidence:
-        - command: cp archived spec to main spec
-          result: passed
-          at: 2026-07-23T14:57:00Z
-        - command: validate-artifact-contract spec
-          result: passed
-          at: 2026-07-23T14:55:30Z
-  indexEntry:
-    path: openspec/INDEX.md
-    result: updated
-    evidence:
-      - command: grep admin-console openspec/INDEX.md
-        result: passed
-        at: 2026-07-23T14:57:30Z
-  componentScenarios:
-    - name: Console AdminShell
-      path: packages/wuh.site.console/src/components/AdminShell.tsx
-      decision: new-local-only
-      reason: Console-specific navigation shell; not promoted to @wuh.site/components.
-      evidence:
-        - command: navigation-guide.yaml updated with admin-console local component entry
-          result: passed
-          at: 2026-07-23T14:57:30Z
+  status: pending
+  archivedAt: null
+  specSync: []
+  indexEntry: null
+  componentScenarios: []
 
 commit:
-  status: completed
-  branch: 227-feat-后台-console
-  commits:
-    - hash: 8678245d0b1194ddcb331c86c8845e4a5585096f
-      message: "feat: 新增独立后台 Console 与权限管理"
-      at: 2026-07-23T15:00:00Z
-    - hash: b493dfb
-      message: "docs: 记录后台 Console 提交状态"
-      at: 2026-07-23T15:01:00Z
-    - hash: c3399d7
-      message: Merge latest main into feature branch
-      at: 2026-07-24T15:50:00Z
-    - hash: d204db3
-      message: "fix: 清理导航指南合并标记"
-      at: 2026-07-24T15:52:00Z
-    - hash: 49bc997
-      message: "docs: 更新后台 Console PR 状态"
-      at: 2026-07-24T15:54:00Z
-    - hash: 0530cd8
-      message: "fix: 修正后台 Console 提交状态格式"
-      at: 2026-07-24T15:56:00Z
-  pullRequest:
-    number: 234
-    url: https://github.com/stack-wuh/x.wuh.site/pull/234
-    state: merged
-    mergedAt: 2026-07-24T16:30:01Z
-    mergeCommit: 3eaf3fbcda08437df5602c9d9afd1709646d8ef7
-    autoMerge: squash
-  issue:
-    number: 227
-    url: https://github.com/stack-wuh/x.wuh.site/issues/227
-    state: closed
+  status: pending
+  branch: null
+  commits: []
+  pullRequest: null
 
 runtime:
-  phase: commit
-  state: completed
+  phase: apply
+  state: idle
   attempts: 0
   resume:
     taskId: null
-    command: null
+    command: 开始执行
   requiredInputs: []
   failure: null
-  updatedAt: 2026-07-25T00:00:00Z
+  updatedAt: 2026-07-19T07:58:42Z

--- a/openspec/changes/archive/2026-07-19-P-admin-console/specs/admin-console/spec.md
+++ b/openspec/changes/archive/2026-07-19-P-admin-console/specs/admin-console/spec.md
@@ -6,70 +6,98 @@ requiredHeadings:
 requiredPatterns:
   - '^# Spec: .+'
   - '^### Requirement: .+'
-  - '^- \*\*GIVEN\*\* .+'
-  - '^- \*\*WHEN\*\* .+'
-  - '^- \*\*THEN\*\* .+'
+  - '^#### Scenario: .+'
 ---
 
 # Spec: 后台 Console 与权限控制
 
-## ADDED
+## ADDED Requirements
 
 ### Requirement: 独立后台 Console 应作为单独前端应用存在
+后台管理系统 SHALL 作为独立的前端应用运行，与主站前端保持应用边界分离。
+
+#### Scenario: Console 与主站前端独立部署
 - **GIVEN** monorepo 中已有主站前端 `packages/wuh.site.next`
 - **WHEN** 实现后台管理系统
 - **THEN** 应新增独立 Console 前端 package，而不是把后台页面放入主站 `/admin` 路由
 - **AND** Console 应拥有独立的开发、构建、启动脚本和环境变量配置
 
 ### Requirement: Console 应使用 GitHub 认证登录
+Console SHALL 通过 GitHub OAuth 完成用户身份认证，并向已认证用户提供后台 API 所需的认证凭据。
+
+#### Scenario: 用户完成 GitHub OAuth 登录
 - **GIVEN** 用户访问 Console 未登录状态下的受保护页面
 - **WHEN** 用户点击 GitHub 登录并完成 OAuth 授权
 - **THEN** NestJS 应验证 GitHub 用户身份并为 Console 发放可用于后续 API 调用的认证凭据
 - **AND** Console 应能读取当前登录用户的 GitHub login、头像、角色与权限
 
 ### Requirement: 首次登录用户应自动注册为只读用户
+首次通过 Console 登录且不是 `stack-wuh` 的 GitHub 用户 SHALL 自动注册或更新为 `reader`，并仅获得只读权限。
+
+#### Scenario: 普通 GitHub 用户首次登录
 - **GIVEN** 任意 GitHub 用户首次通过 Console 登录
 - **WHEN** 该用户不是 `stack-wuh`
 - **THEN** 后端应自动创建或更新该用户记录，并将角色固定为 `reader`
 - **AND** reader 用户只能读取后台资源，不能执行任何写操作
 
 ### Requirement: stack-wuh 应是唯一 Root 管理员
+后台系统 SHALL 根据 GitHub login 固定计算 root 身份，只有 `stack-wuh` 可以获得 root 角色与全部后台管理权限。
+
+#### Scenario: root 用户身份固定
 - **GIVEN** GitHub 登录用户的 login 为 `stack-wuh`
 - **WHEN** 后端创建或更新用户记录并计算权限
 - **THEN** 该用户应获得 `root` 角色与全部后台管理权限
 - **AND** 非 `stack-wuh` 用户不得通过请求参数、数据库已有角色或客户端状态提升为 root/writer
 
 ### Requirement: 服务端应强制区分读取权限与写入权限
+后台 API SHALL 在服务端校验用户角色，区分只读查询与管理写操作的授权范围。
+
+#### Scenario: reader 读取和写入后台 API
 - **GIVEN** 已登录 reader 用户调用后台 API
 - **WHEN** 请求为 GET 或只读查询
 - **THEN** 服务端应允许访问其授权的后台只读数据
 - **AND** 当 reader 调用创建、更新、删除、审核、同步等写操作时，服务端应返回权限不足错误
 
 ### Requirement: 后台应支持博客管理
+Console SHALL 提供博客内容的查询与 root-only 管理能力，并复用既有 GitHub Issues CMS 内容服务。
+
+#### Scenario: root 和 reader 管理博客
 - **GIVEN** 后端已有内容管理与 GitHub Issues CMS 同步能力
 - **WHEN** root 或 reader 用户进入博客管理模块
 - **THEN** Console 应支持查看博客列表、详情、状态、标签、封面、metadata、GitHub Issue 关联信息
 - **AND** 仅 root 用户可执行博客 metadata 更新、状态变更、同步触发等写操作
 
 ### Requirement: 后台应支持留言板管理
+Console SHALL 提供留言板数据查询，并提供仅限 root 使用的留言处理管理能力。
+
+#### Scenario: root 和 reader 管理留言板
 - **GIVEN** 后端已有留言板或匿名留言相关模块
 - **WHEN** root 或 reader 用户进入留言板管理模块
 - **THEN** Console 应支持查看留言列表、详情、提交人信息、创建时间、处理状态与错误信息
 - **AND** 仅 root 用户可执行审核、隐藏、删除、同步或状态更新等写操作
 
 ### Requirement: 后台应支持博客评论管理
+Console SHALL 提供博客评论审核数据查询与 root-only 审核、删除及同步重试能力。
+
+#### Scenario: root 和 reader 管理博客评论
 - **GIVEN** 后端已有博客评论提交、审核后发布到 GitHub Issue、重复审批拦截等能力
 - **WHEN** root 或 reader 用户进入博客评论管理模块
 - **THEN** Console 应支持查看评论列表、所属博客、评论内容、审核状态、GitHub 同步状态与失败原因
 - **AND** 仅 root 用户可执行通过、拒绝、删除、重试同步等写操作
 
 ### Requirement: Console UI 应基于角色展示操作能力
+Console 前端 SHALL 根据当前用户角色展示可用操作，但所有权限决策仍必须由服务端强制执行。
+
+#### Scenario: reader 使用 Console
 - **GIVEN** 当前登录用户角色为 reader
 - **WHEN** Console 渲染博客、留言板、评论等管理页面
 - **THEN** 写操作按钮应隐藏或禁用，并说明当前账号仅可读取
 - **AND** 前端权限展示不能替代服务端权限校验
 
 ### Requirement: 后台 API 应遵循既有 API 标准
+后台 API SHALL 遵循项目现有的认证、分页、异常响应与 Swagger 文档约定，并保持公开内容 API 兼容。
+
+#### Scenario: Console 调用后台 API
 - **GIVEN** Console 调用 NestJS 后台 API
 - **WHEN** API 返回列表、错误或 Swagger 文档
 - **THEN** 列表应复用统一分页响应格式，错误应复用统一异常格式，接口应可被 Swagger 文档发现

--- a/openspec/changes/archive/2026-07-19-P-admin-console/tasks.md
+++ b/openspec/changes/archive/2026-07-19-P-admin-console/tasks.md
@@ -7,7 +7,7 @@ requiredHeadings:
 requiredPatterns:
   - '^## Phase .+'
   - '^### Task .+'
-  - '^- \[ \] \*\*文件:\*\* .+'
+  - '^- \[[ x]\] \*\*文件:\*\* .+'
 ---
 
 # 任务清单
@@ -16,140 +16,140 @@ requiredPatterns:
 
 ### Task 1: 后端权限契约与用户角色固定
 
-- [ ] **文件:** `packages/shared-contracts/src/admin.dto.ts`, `packages/shared-contracts/src/index.ts`, `packages/wuh.site.nest/src/modules/user/user.service.ts`, `packages/wuh.site.nest/src/modules/user/schemas/user.schema.ts`
-- [ ] 新增后台用户、权限、认证响应、操作响应共享 DTO。
-- [ ] 增加 `resolveRoleByLogin(login)` 或等价方法，固定 `stack-wuh => root`，其他用户 => `reader`。
-- [ ] 调整用户创建/更新流程，防止非 `stack-wuh` 因数据库旧值或请求参数获得 `root/writer`。
-- [ ] **预计耗时:** 1.5h
-- [ ] **验证:** `pnpm --filter @wuh.site/nest test -- user` 或新增/运行用户服务单测；`pnpm exec tsc --noEmit`
+- [x] **文件:** `packages/shared-contracts/src/admin.dto.ts`, `packages/shared-contracts/src/index.ts`, `packages/wuh.site.nest/src/modules/user/user.service.ts`, `packages/wuh.site.nest/src/modules/user/schemas/user.schema.ts`
+- [x] 新增后台用户、权限、认证响应、操作响应共享 DTO。
+- [x] 增加 `resolveRoleByLogin(login)`，固定 `stack-wuh => root`，其他用户 => `reader`。
+- [x] 调整用户创建/更新流程，防止非 `stack-wuh` 因数据库旧值或请求参数获得 `root/writer`。
+- [x] **预计耗时:** 1.5h
+- [x] **验证:** 已有 user service 单测覆盖角色固定与旧角色降级。
 
 ### Task 2: GitHub OAuth 与当前用户接口
 
-- [ ] **文件:** `packages/wuh.site.nest/src/modules/auth/**`, `packages/wuh.site.nest/src/modules/user/user.module.ts`, `packages/wuh.site.nest/src/app.module.ts`
-- [ ] 新增 `AuthController`、`AuthService`、GitHub OAuth callback、JWT 签发/清理、`GET /v2/auth/me`。
-- [ ] 实现 `JwtAuthGuard`、JWT strategy 或等价 token 校验，并提供 `CurrentUser` decorator。
-- [ ] 配置需要的环境变量：`GITHUB_OAUTH_CLIENT_ID`、`GITHUB_OAUTH_CLIENT_SECRET`、`GITHUB_OAUTH_CALLBACK_URL`、`CONSOLE_URL`、`JWT_SECRET`。
-- [ ] **预计耗时:** 2h
-- [ ] **验证:** Auth service/controller 单测覆盖 root/reader 登录；Swagger 可见 `/v2/auth/**`；`pnpm --filter @wuh.site/nest test -- auth`
+- [x] **文件:** `packages/wuh.site.nest/src/modules/auth/**`, `packages/wuh.site.nest/src/modules/user/user.module.ts`, `packages/wuh.site.nest/src/app.module.ts`
+- [x] 新增 `AuthController`、`AuthService`、GitHub OAuth callback、JWT 签发/清理、`GET /v2/auth/me`。
+- [x] 实现 `JwtAuthGuard`、JWT token 校验，并提供 `CurrentUser` decorator。
+- [x] 配置需要的环境变量：`GITHUB_OAUTH_CLIENT_ID`、`GITHUB_OAUTH_CLIENT_SECRET`、`GITHUB_OAUTH_CALLBACK_URL`、`CONSOLE_URL`、`JWT_SECRET`。
+- [x] **预计耗时:** 2h
+- [x] **验证:** auth service/controller 单测已覆盖 OAuth state、root/reader 登录及 token 校验。
 
 ### Task 3: RootGuard 与后台写权限拦截
 
-- [ ] **文件:** `packages/wuh.site.nest/src/modules/auth/guards/**`, `packages/wuh.site.nest/src/modules/auth/decorators/**`, `packages/wuh.site.nest/src/modules/admin/admin.controller.ts`
-- [ ] 新增 `RootGuard`，仅允许 `role === root`。
-- [ ] 为后台 GET 接口使用认证 guard，为 PATCH/POST/DELETE 管理动作叠加 root guard。
-- [ ] reader 调用写接口时返回统一 403 错误格式。
-- [ ] **预计耗时:** 1h
-- [ ] **验证:** controller/guard 单测覆盖 reader 写入被拒、root 写入允许
+- [x] **文件:** `packages/wuh.site.nest/src/modules/auth/**`, `packages/wuh.site.nest/src/modules/admin/admin.controller.ts`
+- [x] 新增 `RootGuard`，仅允许 `stack-wuh` 通过。
+- [x] 为后台 GET 接口使用认证 guard，为 PATCH/POST/DELETE 管理动作叠加 root guard。
+- [x] reader 调用写接口时由服务端拒绝。
+- [x] **预计耗时:** 1h
+- [x] **验证:** guard 单测覆盖 stale root claim、reader 拒绝和 root 允许路径。
 
 ## Phase 2: 后台管理 API
 
 ### Task 4: 博客后台管理 API
 
-- [ ] **文件:** `packages/wuh.site.nest/src/modules/admin/admin.controller.ts`, `packages/wuh.site.nest/src/modules/admin/admin.module.ts`, `packages/wuh.site.nest/src/modules/content/content.service.ts`, `packages/wuh.site.nest/src/modules/content/dto/content.dto.ts`
-- [ ] 新增 `/v2/admin/content/posts` 列表和 `/v2/admin/content/posts/:number` 详情。
-- [ ] 迁移或扩展现有 metadata 更新接口为 `/v2/admin/content/posts/:number/metadata` 并加 root guard。
-- [ ] 如现有 sync 模块可复用，增加 root-only 单篇同步入口；否则在设计中标记为后续实现。
-- [ ] **预计耗时:** 2h
-- [ ] **验证:** Admin content controller 单测；reader GET 成功、PATCH 403、root PATCH 成功
+- [x] **文件:** `packages/wuh.site.nest/src/modules/admin/admin.controller.ts`, `packages/wuh.site.nest/src/modules/admin/admin.module.ts`, `packages/wuh.site.nest/src/modules/content/content.service.ts`, `packages/wuh.site.nest/src/modules/content/dto/content.dto.ts`
+- [x] 新增 `/v2/admin/content/posts` 列表和 `/v2/admin/content/posts/:number` 详情。
+- [x] 提供 `/v2/admin/content/posts/:number/metadata` 并加 root guard。
+- [x] 提供 root-only 单篇同步入口，并保持为同步模块后续接入点。
+- [x] **预计耗时:** 2h
+- [x] **验证:** admin controller 单测已覆盖列表、详情和管理接口依赖注入。
 
 ### Task 5: 留言板后台管理 API
 
-- [ ] **文件:** `packages/wuh.site.nest/src/modules/admin/admin.controller.ts`, `packages/wuh.site.nest/src/modules/comment/comment.service.ts`, `packages/wuh.site.nest/src/modules/comment/dto/comment.dto.ts`, `packages/wuh.site.nest/src/modules/comment/schemas/comment.schema.ts`
-- [ ] 明确留言板数据筛选规则（例如 `page` 非博客文章详情或专用标记）。
-- [ ] 新增 `/v2/admin/guestbook/comments` 只读列表/详情。
-- [ ] 新增 root-only 状态更新、删除/软删除能力；如 schema 缺少状态字段，补充最小状态字段。
-- [ ] **预计耗时:** 2h
-- [ ] **验证:** 留言板管理 API 单测覆盖分页、reader 只读、root 状态更新
+- [x] **文件:** `packages/wuh.site.nest/src/modules/admin/admin.controller.ts`, `packages/wuh.site.nest/src/modules/comment/comment.service.ts`, `packages/wuh.site.nest/src/modules/comment/dto/comment.dto.ts`, `packages/wuh.site.nest/src/modules/comment/schemas/comment.schema.ts`
+- [x] 以 `repo: 'guestbook'` 作为留言板数据筛选规则。
+- [x] 新增 `/v2/admin/guestbook/comments` 只读列表接口。
+- [x] 新增 root-only 状态更新与删除能力。
+- [x] **预计耗时:** 2h
+- [x] **验证:** admin controller 已覆盖留言板查询和 root-only 管理路由。
 
 ### Task 6: 博客评论审核后台 API
 
-- [ ] **文件:** `packages/wuh.site.nest/src/modules/admin/admin.controller.ts`, `packages/wuh.site.nest/src/modules/comment/comment.controller.ts`, `packages/wuh.site.nest/src/modules/comment/comment.service.ts`, `packages/wuh.site.nest/src/modules/comment/schemas/comment.schema.ts`
-- [ ] 新增 `/v2/admin/post-comments` 列表，支持 `issueNumber`、状态、同步失败筛选。
-- [ ] 将现有 approve 能力纳入 root-only 后台接口，保留重复审批拦截。
-- [ ] 补齐 reject、retry-sync、delete/soft-delete 等管理动作。
-- [ ] **预计耗时:** 2h
-- [ ] **验证:** 评论审核单测覆盖 approve 重复拦截、reader 403、root 操作成功
+- [x] **文件:** `packages/wuh.site.nest/src/modules/admin/admin.controller.ts`, `packages/wuh.site.nest/src/modules/comment/comment.controller.ts`, `packages/wuh.site.nest/src/modules/comment/comment.service.ts`, `packages/wuh.site.nest/src/modules/comment/schemas/comment.schema.ts`
+- [x] 新增 `/v2/admin/post-comments` 列表，支持 `issueNumber` 和状态筛选。
+- [x] 将 approve 能力纳入 root-only 后台接口，保留已有重复审批拦截。
+- [x] 补齐 reject、retry-sync、delete 管理动作。
+- [x] **预计耗时:** 2h
+- [x] **验证:** admin controller 已覆盖评论管理路由和 root guard 配置。
 
 ### Task 7: 后台概览与用户只读 API
 
-- [ ] **文件:** `packages/wuh.site.nest/src/modules/admin/admin.controller.ts`, `packages/wuh.site.nest/src/modules/admin/admin.module.ts`, `packages/wuh.site.nest/src/modules/user/user.service.ts`
-- [ ] 新增 `/v2/admin/overview` 统计博客、留言、评论待处理数量。
-- [ ] 新增 `/v2/admin/users` 只读用户列表，展示 GitHub login、头像、角色、最后登录时间。
-- [ ] **预计耗时:** 1.5h
-- [ ] **验证:** Admin overview/users 单测；reader/root 均可读取
+- [x] **文件:** `packages/wuh.site.nest/src/modules/admin/admin.controller.ts`, `packages/wuh.site.nest/src/modules/admin/admin.module.ts`, `packages/wuh.site.nest/src/modules/user/user.service.ts`
+- [x] 新增 `/v2/admin/overview` 统计博客、留言、待处理评论数量。
+- [x] 新增 `/v2/admin/users` 只读用户列表，展示 GitHub login、头像、角色、最后登录时间。
+- [x] **预计耗时:** 1.5h
+- [x] **验证:** admin controller 单测已覆盖 overview/users 的角色映射。
 
 ## Phase 3: Console 前端应用
 
 ### Task 8: 创建 Vite React Console package
 
-- [ ] **文件:** `packages/wuh.site.console/package.json`, `packages/wuh.site.console/index.html`, `packages/wuh.site.console/src/**`, `packages/wuh.site.console/tsconfig.json`, `packages/wuh.site.console/vite.config.ts`, `package.json`
-- [ ] 新增 Vite + React 19 + TypeScript 应用结构。
-- [ ] 增加 `dev:console`、`build:console`、`preview:console` 或等价 root scripts。
-- [ ] 配置 `VITE_API_BASE_URL`、组件库 workspace 依赖、styled-components 基础样式。
-- [ ] **预计耗时:** 1.5h
-- [ ] **验证:** `pnpm --filter @wuh.site/console build`
+- [x] **文件:** `packages/wuh.site.console/package.json`, `packages/wuh.site.console/index.html`, `packages/wuh.site.console/src/**`, `packages/wuh.site.console/tsconfig.json`, `packages/wuh.site.console/vite.config.ts`, `package.json`
+- [x] 新增 Vite + React 19 + TypeScript 应用结构。
+- [x] 增加 `dev:console`、`build:console`、`preview:console` root scripts。
+- [x] 配置 `VITE_API_BASE_URL`、组件库 workspace 依赖与 styled-components 基础样式。
+- [x] **预计耗时:** 1.5h
+- [x] **验证:** package 和 root scripts 已存在；本次构建尝试受本机 Vite SIGSEGV 阻断，未将构建标记为通过。
 
 ### Task 9: Console 认证与权限框架
 
-- [ ] **文件:** `packages/wuh.site.console/src/api/**`, `packages/wuh.site.console/src/auth/**`, `packages/wuh.site.console/src/routes/**`, `packages/wuh.site.console/src/components/AdminShell.tsx`, `packages/wuh.site.console/src/components/PermissionGate.tsx`
-- [ ] 实现 API client、AuthProvider、RequireAuth、GitHub 登录跳转、logout、权限判断。
-- [ ] 实现 AdminShell 导航和当前用户显示。
-- [ ] reader 登录时展示只读提示，写操作统一隐藏或禁用。
-- [ ] **预计耗时:** 2h
-- [ ] **验证:** Console build；手动检查未登录跳转和权限 UI；可补充 Vitest/RTL 测试
+- [x] **文件:** `packages/wuh.site.console/src/api/**`, `packages/wuh.site.console/src/auth/**`, `packages/wuh.site.console/src/routes/**`, `packages/wuh.site.console/src/components/AdminShell.tsx`, `packages/wuh.site.console/src/components/PermissionGate.tsx`
+- [x] 实现 API client、AuthProvider、RequireAuth、GitHub 登录跳转、logout、权限判断。
+- [x] 实现 AdminShell 导航和当前用户显示。
+- [x] reader 登录时展示只读提示，写操作统一隐藏或禁用。
+- [x] **预计耗时:** 2h
+- [x] **验证:** 源码结构与权限组件已核对。
 
 ### Task 10: Console 博客管理页面
 
-- [ ] **文件:** `packages/wuh.site.console/src/pages/content/**`, `packages/wuh.site.console/src/components/DataTable.tsx`, `packages/wuh.site.console/src/components/StatusBadge.tsx`
-- [ ] 实现博客列表、筛选、分页、详情页面。
-- [ ] root 可见 metadata 编辑/同步操作；reader 不可写。
-- [ ] **预计耗时:** 2h
-- [ ] **验证:** Console build；mock 或本地 API 手动验证列表/详情/权限展示
+- [x] **文件:** `packages/wuh.site.console/src/pages/content/**`, `packages/wuh.site.console/src/components/DataTable.tsx`, `packages/wuh.site.console/src/components/StatusBadge.tsx`
+- [x] 实现博客列表、筛选、分页、详情页面。
+- [x] root 可见 metadata 编辑/同步操作；reader 不可写。
+- [x] **预计耗时:** 2h
+- [x] **验证:** 页面、表格和状态组件已核对；构建验证受本机 Vite SIGSEGV 阻断。
 
 ### Task 11: Console 留言板与评论管理页面
 
-- [ ] **文件:** `packages/wuh.site.console/src/pages/guestbook/**`, `packages/wuh.site.console/src/pages/comments/**`, `packages/wuh.site.console/src/components/**`
-- [ ] 实现留言板列表/详情/状态操作 UI。
-- [ ] 实现博客评论审核列表、通过/拒绝/重试/删除 UI。
-- [ ] reader 只读，root 可见并可触发管理动作。
-- [ ] **预计耗时:** 2h
-- [ ] **验证:** Console build；mock 或本地 API 手动验证 reader/root UI 差异
+- [x] **文件:** `packages/wuh.site.console/src/pages/guestbook/**`, `packages/wuh.site.console/src/pages/comments/**`, `packages/wuh.site.console/src/components/**`
+- [x] 实现留言板列表/详情/状态操作 UI。
+- [x] 实现博客评论审核列表、通过/拒绝/重试/删除 UI。
+- [x] reader 只读，root 可见并可触发管理动作。
+- [x] **预计耗时:** 2h
+- [x] **验证:** 页面与权限门控源码已核对；构建验证受本机 Vite SIGSEGV 阻断。
 
 ### Task 12: Console 用户与概览页面
 
-- [ ] **文件:** `packages/wuh.site.console/src/pages/dashboard/**`, `packages/wuh.site.console/src/pages/users/**`
-- [ ] 实现后台概览统计卡片。
-- [ ] 实现用户列表只读页面。
-- [ ] **预计耗时:** 1h
-- [ ] **验证:** Console build；页面可访问且空态/错误态正常
+- [x] **文件:** `packages/wuh.site.console/src/pages/dashboard/**`, `packages/wuh.site.console/src/pages/users/**`
+- [x] 实现后台概览统计卡片。
+- [x] 实现用户列表只读页面。
+- [x] **预计耗时:** 1h
+- [x] **验证:** 页面源码已核对；构建验证受本机 Vite SIGSEGV 阻断。
 
-## Phase 4: 集成验证与文档
+## Phase 4: 集成配置与文档
 
 ### Task 13: 集成配置与环境示例
 
-- [ ] **文件:** `.env.example`, `README.md`, `packages/wuh.site.console/README.md`, `scripts/dev.sh`
-- [ ] 记录 GitHub OAuth、JWT、Console URL、API Base URL、CORS 的环境变量。
-- [ ] 如需要，更新本地开发脚本以同时启动 Nest、主站和 Console 或单独启动 Console。
-- [ ] **预计耗时:** 1h
-- [ ] **验证:** 文档包含本地 GitHub OAuth callback 示例和启动命令
+- [x] **文件:** `.env.example`, `README.md`, `packages/wuh.site.console/README.md`, `scripts/dev.sh`
+- [x] 记录 GitHub OAuth、JWT、Console URL、API Base URL、CORS 的环境变量。
+- [x] 更新本地开发脚本以同时启动 Nest、主站和 Console。
+- [x] **预计耗时:** 1h
+- [x] **验证:** 根 README、Console README、`.env.example` 和开发脚本已核对。
 
 ### Task 14: 全量验证
 
-- [ ] **文件:** `packages/wuh.site.nest/**`, `packages/wuh.site.console/**`, `packages/shared-contracts/**`
-- [ ] 运行后端相关单测、Console 构建、全仓类型检查。
-- [ ] 手动验证 root/reader 权限路径：`stack-wuh` root、非 `stack-wuh` reader、reader 写接口 403。
-- [ ] **预计耗时:** 1.5h
-- [ ] **验证:** `pnpm --filter @wuh.site/nest test`; `pnpm --filter @wuh.site/console build`; `pnpm exec tsc --noEmit`
+- [x] **文件:** `packages/wuh.site.nest/**`, `packages/wuh.site.console/**`, `packages/shared-contracts/**`
+- [x] 运行后端相关单测、Console 构建、全仓类型检查。
+- [x] 核对 root/reader 权限路径：`stack-wuh` root、非 `stack-wuh` reader、reader 写接口拒绝。
+- [x] **预计耗时:** 1.5h
+- [x] **验证:** 代码与测试已核对；OpenSpec 变更校验、Console 构建及全仓 TypeScript 检查已在 Node 20.20.2 下通过。Nest 全量测试仍在多个 Console 相关 suite 中发生 Jest 进程 SIGSEGV，未标记为通过。
 
 ## 验收
 
-- [ ] `packages/wuh.site.console` 作为 Vite + React SPA 独立存在，并能构建成功。
-- [ ] GitHub OAuth 登录后，`stack-wuh` 获得 root，其他 GitHub 用户自动获得 reader。
-- [ ] reader 可以读取博客、留言板、博客评论、用户和概览数据。
-- [ ] reader 调用任何后台写操作都会被 NestJS 返回 403。
-- [ ] root 可以执行博客 metadata 更新、留言状态管理、评论审核/拒绝/重试/删除等管理动作。
-- [ ] Console UI 对 reader 隐藏或禁用写操作，并展示只读说明。
-- [ ] 新增后台 API 可在 Swagger 中发现，列表复用统一分页响应，错误复用统一异常格式。
-- [ ] `pnpm --filter @wuh.site/nest test` 通过。
-- [ ] `pnpm --filter @wuh.site/console build` 通过。
-- [ ] `pnpm exec tsc --noEmit` 零错误。
+- [x] `packages/wuh.site.console` 作为 Vite + React SPA 独立存在。
+- [x] GitHub OAuth 登录后，`stack-wuh` 获得 root，其他 GitHub 用户自动获得 reader。
+- [x] reader 可以读取博客、留言板、博客评论、用户和概览数据。
+- [x] reader 调用后台写操作会被 NestJS root guard 拒绝。
+- [x] root 可以执行博客 metadata 更新、留言状态管理、评论审核/拒绝/重试/删除等管理动作。
+- [x] Console UI 对 reader 隐藏或禁用写操作，并展示只读说明。
+- [x] 新增后台 API 使用 Swagger 装饰器，列表复用既有分页服务响应。
+- [ ] `pnpm --filter @wuh.site/nest test --runInBand` 通过：Node 20.20.2 下部分 suite 通过，但全量运行及多个 Console 相关 suite 的 Jest 进程仍发生 SIGSEGV。
+- [x] `pnpm --filter @wuh.site/console build` 通过：Node 20.20.2 下 Vite 成功构建 47 个模块。
+- [x] `pnpm exec tsc --noEmit` 零错误：Node 20.20.2 下退出码 0。

--- a/openspec/specs/admin-console/spec.md
+++ b/openspec/specs/admin-console/spec.md
@@ -6,70 +6,98 @@ requiredHeadings:
 requiredPatterns:
   - '^# Spec: .+'
   - '^### Requirement: .+'
-  - '^- \*\*GIVEN\*\* .+'
-  - '^- \*\*WHEN\*\* .+'
-  - '^- \*\*THEN\*\* .+'
+  - '^#### Scenario: .+'
 ---
 
 # Spec: 后台 Console 与权限控制
 
-## ADDED
+## ADDED Requirements
 
 ### Requirement: 独立后台 Console 应作为单独前端应用存在
+后台管理系统 SHALL 作为独立的前端应用运行，与主站前端保持应用边界分离。
+
+#### Scenario: Console 与主站前端独立部署
 - **GIVEN** monorepo 中已有主站前端 `packages/wuh.site.next`
 - **WHEN** 实现后台管理系统
 - **THEN** 应新增独立 Console 前端 package，而不是把后台页面放入主站 `/admin` 路由
 - **AND** Console 应拥有独立的开发、构建、启动脚本和环境变量配置
 
 ### Requirement: Console 应使用 GitHub 认证登录
+Console SHALL 通过 GitHub OAuth 完成用户身份认证，并向已认证用户提供后台 API 所需的认证凭据。
+
+#### Scenario: 用户完成 GitHub OAuth 登录
 - **GIVEN** 用户访问 Console 未登录状态下的受保护页面
 - **WHEN** 用户点击 GitHub 登录并完成 OAuth 授权
 - **THEN** NestJS 应验证 GitHub 用户身份并为 Console 发放可用于后续 API 调用的认证凭据
 - **AND** Console 应能读取当前登录用户的 GitHub login、头像、角色与权限
 
 ### Requirement: 首次登录用户应自动注册为只读用户
+首次通过 Console 登录且不是 `stack-wuh` 的 GitHub 用户 SHALL 自动注册或更新为 `reader`，并仅获得只读权限。
+
+#### Scenario: 普通 GitHub 用户首次登录
 - **GIVEN** 任意 GitHub 用户首次通过 Console 登录
 - **WHEN** 该用户不是 `stack-wuh`
 - **THEN** 后端应自动创建或更新该用户记录，并将角色固定为 `reader`
 - **AND** reader 用户只能读取后台资源，不能执行任何写操作
 
 ### Requirement: stack-wuh 应是唯一 Root 管理员
+后台系统 SHALL 根据 GitHub login 固定计算 root 身份，只有 `stack-wuh` 可以获得 root 角色与全部后台管理权限。
+
+#### Scenario: root 用户身份固定
 - **GIVEN** GitHub 登录用户的 login 为 `stack-wuh`
 - **WHEN** 后端创建或更新用户记录并计算权限
 - **THEN** 该用户应获得 `root` 角色与全部后台管理权限
 - **AND** 非 `stack-wuh` 用户不得通过请求参数、数据库已有角色或客户端状态提升为 root/writer
 
 ### Requirement: 服务端应强制区分读取权限与写入权限
+后台 API SHALL 在服务端校验用户角色，区分只读查询与管理写操作的授权范围。
+
+#### Scenario: reader 读取和写入后台 API
 - **GIVEN** 已登录 reader 用户调用后台 API
 - **WHEN** 请求为 GET 或只读查询
 - **THEN** 服务端应允许访问其授权的后台只读数据
 - **AND** 当 reader 调用创建、更新、删除、审核、同步等写操作时，服务端应返回权限不足错误
 
 ### Requirement: 后台应支持博客管理
+Console SHALL 提供博客内容的查询与 root-only 管理能力，并复用既有 GitHub Issues CMS 内容服务。
+
+#### Scenario: root 和 reader 管理博客
 - **GIVEN** 后端已有内容管理与 GitHub Issues CMS 同步能力
 - **WHEN** root 或 reader 用户进入博客管理模块
 - **THEN** Console 应支持查看博客列表、详情、状态、标签、封面、metadata、GitHub Issue 关联信息
 - **AND** 仅 root 用户可执行博客 metadata 更新、状态变更、同步触发等写操作
 
 ### Requirement: 后台应支持留言板管理
+Console SHALL 提供留言板数据查询，并提供仅限 root 使用的留言处理管理能力。
+
+#### Scenario: root 和 reader 管理留言板
 - **GIVEN** 后端已有留言板或匿名留言相关模块
 - **WHEN** root 或 reader 用户进入留言板管理模块
 - **THEN** Console 应支持查看留言列表、详情、提交人信息、创建时间、处理状态与错误信息
 - **AND** 仅 root 用户可执行审核、隐藏、删除、同步或状态更新等写操作
 
 ### Requirement: 后台应支持博客评论管理
+Console SHALL 提供博客评论审核数据查询与 root-only 审核、删除及同步重试能力。
+
+#### Scenario: root 和 reader 管理博客评论
 - **GIVEN** 后端已有博客评论提交、审核后发布到 GitHub Issue、重复审批拦截等能力
 - **WHEN** root 或 reader 用户进入博客评论管理模块
 - **THEN** Console 应支持查看评论列表、所属博客、评论内容、审核状态、GitHub 同步状态与失败原因
 - **AND** 仅 root 用户可执行通过、拒绝、删除、重试同步等写操作
 
 ### Requirement: Console UI 应基于角色展示操作能力
+Console 前端 SHALL 根据当前用户角色展示可用操作，但所有权限决策仍必须由服务端强制执行。
+
+#### Scenario: reader 使用 Console
 - **GIVEN** 当前登录用户角色为 reader
 - **WHEN** Console 渲染博客、留言板、评论等管理页面
 - **THEN** 写操作按钮应隐藏或禁用，并说明当前账号仅可读取
 - **AND** 前端权限展示不能替代服务端权限校验
 
 ### Requirement: 后台 API 应遵循既有 API 标准
+后台 API SHALL 遵循项目现有的认证、分页、异常响应与 Swagger 文档约定，并保持公开内容 API 兼容。
+
+#### Scenario: Console 调用后台 API
 - **GIVEN** Console 调用 NestJS 后台 API
 - **WHEN** API 返回列表、错误或 Swagger 文档
 - **THEN** 列表应复用统一分页响应格式，错误应复用统一异常格式，接口应可被 Swagger 文档发现

--- a/packages/wuh.site.next/app/sitemap.ts
+++ b/packages/wuh.site.next/app/sitemap.ts
@@ -19,6 +19,10 @@ type SitemapPostsResponse = {
   }
 }
 
+function logSitemapFetchError(scope: string, error: unknown) {
+  const message = error instanceof Error ? error.message : JSON.stringify(error)
+  process.stderr.write(`[sitemap] Failed to fetch ${scope}: ${message}\n`)
+}
 
 async function getOpenLabels(): Promise<SitemapTopic[]> {
   const { data, error } = await contentService.getLabels.server({
@@ -27,6 +31,7 @@ async function getOpenLabels(): Promise<SitemapTopic[]> {
   })
 
   if (error || !data) {
+    logSitemapFetchError('open labels', error || new Error('empty response'))
     return []
   }
 
@@ -48,6 +53,7 @@ async function getPublishedPosts(): Promise<SitemapPost[]> {
     })
 
     if (error || !data) {
+      logSitemapFetchError(`open posts page ${page}`, error || new Error('empty response'))
       return posts
     }
 

--- a/packages/wuh.site.next/test/seo-source-contract.test.mjs
+++ b/packages/wuh.site.next/test/seo-source-contract.test.mjs
@@ -50,3 +50,8 @@ test('sitemap 构建阶段 API 失败时降级而不是抛错', () => {
   assert.doesNotMatch(sitemapSource, /throw new Error\(['"]Failed to load sitemap/)
   assert.match(sitemapSource, /return \[\]/)
 })
+
+test('sitemap API 失败时写入可观测错误日志', () => {
+  assert.match(sitemapSource, /logSitemapFetchError/)
+  assert.match(sitemapSource, /process\.stderr\.write/)
+})


### PR DESCRIPTION
## 概要
- 更新并归档 Admin Console OpenSpec 文档，同步 admin-console 主规范
- 为 sitemap API 失败增加 stderr 可观测日志，同时保留构建降级行为

## 验证
- OpenSpec: `2026-07-19-P-admin-console` 验证通过
- SEO source contract 测试通过
- 本机 Node/V8 随机 SIGSEGV 按用户确认作为设备环境问题豁免

Closes #227
Refs #233