### PR TITLE
chore: 建立全站图片语义角色体系 (#266)

### DIFF
--- a/openspec/INDEX.md
+++ b/openspec/INDEX.md
@@ -4,8 +4,8 @@
 > 每个领域列出核心需求和关键词，匹配后可深入阅读对应 spec.md。
 
 ## components — 组件包
-- **关键词:** 组件库, exports map, 导入路径, pnpm workspace, 图片预览, 动画, framer-motion
-- **需求:** 组件包使用 exports map 导出, 图片切换有过渡动画, 缩放和旋转有弹性动画, ImagePreview 组件代码按职责拆分
+- **关键词:** 组件库, exports map, 图片组件, 语义角色, 头像, 书封, 二维码, 透明背景, 图片预览, 动画, framer-motion
+- **需求:** 组件包使用 exports map 导出, 图片切换有过渡动画, 缩放和旋转有弹性动画, ImagePreview 组件代码按职责拆分, Image 支持语义角色, 图片外轮廓由 Wrapper 单点负责, 内部图片提供正式样式通道, 未传 role 时保持兼容, 头像角色使用圆形透明外观, 书封角色保持实体书轮廓, 内容图片具有稳定阅读外观, 页面封面圆角由上下文明确控制, 缩略图使用紧凑状态, Logo 保持透明完整, 二维码保持可扫描性, 专用图片链路保持例外
 - **路径:** `openspec/specs/components/spec.md`
 
 ## content-api — 内容 API

--- a/openspec/changes/archive/2026-07-25-P-semantic-image-roles/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-25-P-semantic-image-roles/.openspec.yaml
@@ -1,0 +1,7 @@
+project: x.wuh.site
+change: semantic-image-roles
+date: 2026-07-25
+type: P
+status: proposed
+category: chore
+issue: https://github.com/stack-wuh/x.wuh.site/issues/266

--- a/openspec/changes/archive/2026-07-25-P-semantic-image-roles/design.md
+++ b/openspec/changes/archive/2026-07-25-P-semantic-image-roles/design.md
@@ -1,0 +1,192 @@
+# 全站图片语义角色设计
+
+## 架构
+
+本次将共享 Image 从“统一默认视觉 + 页面局部覆盖”调整为“语义角色预设 + 显式属性覆盖 + 兼容默认值”。
+
+```text
+Image 调用
+  ├─ role 语义角色
+  │    ├─ Wrapper: radius / background / border / overflow
+  │    ├─ Skeleton: 继承 Wrapper 形状
+  │    ├─ Fallback: 继承角色尺寸与密度
+  │    └─ Img: object-fit / filter / transform
+  ├─ 显式属性覆盖
+  │    ├─ borderRadius
+  │    ├─ appearance
+  │    ├─ variant
+  │    ├─ imageClassName
+  │    └─ imageStyle
+  └─ 未传 role
+       ├─ 保持当前兼容行为
+       └─ 开发环境输出迁移提示
+```
+
+视觉属性优先级：
+
+```text
+调用方显式属性 > role 预设 > 兼容默认值
+```
+
+所有角色均由共享 Image 的 Wrapper 单点负责可见外轮廓。页面不再通过只作用于内部 `<img>` 的 inline style 修补圆角或背景。
+
+## 技术选型
+
+| 维度 | 选择 | 理由 |
+|------|------|------|
+| API | `role?: ImageRole` | 直接表达图片语义，避免页面重复组合圆角、背景和 fit |
+| 兼容策略 | 无 role 时保持旧行为，并仅在开发环境提示 | 完成仓库内迁移的同时避免破坏未知组件库消费者 |
+| 角色范围 | avatar/book-cover/content/cover/thumbnail/logo/qr | 均来自仓库真实调用，不创建未使用角色 |
+| 书封圆角 | 2px | 小尺寸书封更接近实体书轮廓，避免 4–16px 过度圆润 |
+| 头像背景 | transparent | 透明区域直接显示页面背景，不出现黑底或额外底盘 |
+| 内容图 | 8px + 内容底色 + 轻边框 | 与现有 Markdown 编辑式视觉一致，并稳定承载透明 PNG |
+| Logo | 0px + plain + contain | 避免透明 SVG 被默认背景、边框和裁切污染 |
+| QR | 2px + white + contain | 保留扫码静区与亮暗主题下的高对比度 |
+| 内部样式通道 | `imageClassName` / `imageStyle` | 修复当前 class 只落在 Wrapper、Logo filter 无法稳定应用的问题 |
+| HTML 图片 | CSS normalization | dangerouslySetInnerHTML 链路无法直接使用 React Image，但可共享视觉规范 |
+| 测试 | 组件契约测试 + 页面源码契约 + 浏览器视觉验收 | 覆盖 API、迁移完整性、亮暗主题与加载/错误状态 |
+
+## 复用分析
+
+| 现有能力 | 决策 |
+|----------|------|
+| `ImageProps.variant` | 保留，作为 role 默认 object-fit 的显式覆盖 |
+| `ImageProps.appearance` | 保留，作为 role 背景/边框的显式覆盖 |
+| `ImageProps.borderRadius` | 保留，优先级高于 role 预设 |
+| Skeleton / errorFallback | 复用状态机，按 role 改变形状和密度 |
+| `styled(Image)` | 继续支持 Wrapper 尺寸与布局；不再用于假定控制内部图片 |
+| ImagePreview | 保留专用 `<img>`，因其依赖 transform、手势与按钮内图片动画 |
+| Markdown/评论/足迹 HTML | 保留 HTML 链路，补齐 role 对应的 CSS 规范 |
+
+## 数据模型
+
+```ts
+export type ImageRole =
+  | 'avatar'
+  | 'book-cover'
+  | 'content'
+  | 'cover'
+  | 'thumbnail'
+  | 'logo'
+  | 'qr'
+
+export interface ImageProps {
+  role?: ImageRole
+  imageClassName?: string
+  imageStyle?: React.CSSProperties
+  // 现有 props 保持不变
+}
+```
+
+角色预设只提供默认值，不锁死调用方尺寸。`priority`、`width`、`height`、`ratio` 和 `sizes` 仍由具体页面根据布局和首屏位置决定。
+
+## API 设计
+
+无后端 API 变更。
+
+### 角色默认值
+
+| Role | Wrapper radius | Wrapper background | Border | Variant | Skeleton/Fallback |
+|------|----------------|--------------------|--------|---------|-------------------|
+| `avatar` | `50%` | transparent | none | cover | 圆形、紧凑 |
+| `book-cover` | `2px` | 中性纸张色 | 极弱边线 | contain | 同书封形状 |
+| `content` | `8px` | `--background-100` | 轻边框 | contain | 常规内容态 |
+| `cover` | 可由上下文覆盖 | 中性加载底 | none | cover | 宽幅加载态 |
+| `thumbnail` | `8px` | 中性底 | none | cover | 紧凑，无大段文字 |
+| `logo` | `0` | transparent | none | contain | 默认关闭 Skeleton |
+| `qr` | `2px` | `#fff` | 白色静区 | contain | 紧凑且保留白底 |
+
+### 内部图片样式
+
+- `className` 继续落在 Wrapper。
+- `imageClassName` 仅落在内部 Next Image / `<img>`。
+- `imageStyle` 仅落在内部图片。
+- `style` 不再依赖未声明的透传行为；Wrapper 样式继续通过 styled-components 或正式 Wrapper style API 管理。
+
+## 组件/模块设计
+
+### Image role resolver
+
+- 集中保存角色默认值，禁止在 JSX 中散落多层条件。
+- 解析时先取 role 预设，再应用显式 `variant`、`appearance`、`borderRadius`。
+- 未传 role 时保留当前默认 `cover`、默认 appearance 和默认圆角。
+- 开发环境每个调用点或每个 role-less 实例发出可控提示；生产环境不输出日志。
+
+### Wrapper 与状态层
+
+- Wrapper 始终持有最终圆角、背景、边框和 `overflow:hidden`。
+- Skeleton 和 fallback 使用 `inset:0`，自然继承 Wrapper 外轮廓。
+- `avatar` fallback 不显示方形大文本；优先使用紧凑图标或调用方首字母 fallback。
+- `thumbnail`、`qr` 等小尺寸角色不显示“图片加载失败”长文案。
+- `prefers-reduced-motion` 下关闭 shimmer 和 opacity transition。
+
+### 页面迁移
+
+#### Avatar
+
+- About GitHub 头像移除内部 `style={{ borderRadius: '50%' }}`，改为 `role='avatar'`。
+- 文章作者头像迁移并保留现有 accent ring；ring 由外部容器或 Wrapper 扩展样式负责。
+- 评论头像迁移时保留无图片首字母 fallback，不改变评论身份展示逻辑。
+
+#### Book cover
+
+- 首页与微信读书页统一 `role='book-cover'`。
+- 删除页面重复的 appearance、variant 和 4px 圆角；尺寸、flex 和局部阴影强度可留在页面。
+- 中性纸张底色同时适配酒红/素雅和浅色/深色主题。
+
+#### Cover
+
+- 文章头图改为 `role='cover'`。
+- 桌面圆角与移动端 0 圆角必须落在 Image Wrapper，不允许父 12px、子 16px 双重裁切。
+- 保留首屏 priority、16:9 和移动端 edge-to-edge 行为。
+
+#### Logo
+
+- 首页和 ContactCard Logo 改为 `role='logo'`。
+- 使用 `imageClassName` 或 `imageStyle` 应用暗色 filter，移除当前无效的内部选择器假设。
+
+#### Thumbnail
+
+- 足迹照片迁移到 `role='thumbnail'`，保留点击预览与 1:1 比例。
+- ImagePreview 内部 ThumbnailRail 明确保留专用实现。
+
+#### QR
+
+- ContactCard 二维码迁移到 `role='qr'`，使用 contain 和白色静区。
+- 微信分享 popup 原生 QR 保持不变。
+
+### HTML 内容图片规范
+
+Markdown 正文、评论 HTML 与足迹正文中的图片统一：
+
+- `max-width: 100%`
+- `height: auto`
+- 8px 圆角
+- `--background-100` 背景
+- 轻边框
+- 透明图可读
+- 不产生横向滚动
+
+这些规则与 `content` role 视觉一致，但不伪装成 React Image 迁移。
+
+## 响应式策略
+
+| 场景 | 行为 |
+|------|------|
+| 书封 | 保持调用方固定小尺寸，2px 圆角不随断点放大 |
+| 头像 | 保持 1:1 圆形，不因 flex 收缩变形 |
+| 内容图 | 宽度不超过内容容器，高度按源比例自适应 |
+| 文章封面 | 桌面保留页面圆角；移动端 Wrapper 圆角明确为 0 并 edge-to-edge |
+| 缩略图 | 维持既定 ratio 与 cover，不挤压相邻文本 |
+| Logo | 保持 intrinsic ratio，不裁切透明边缘 |
+| QR | 保持 1:1 和白色静区，不被窄屏压缩到不可扫描尺寸 |
+
+## 影响分析
+
+- **新增依赖:** 无。
+- **破坏性变更:** 无；role 为可选，现有属性保留。
+- **向后兼容:** 未传 role 的消费者保持当前行为；开发环境提示后续迁移。
+- **性能影响:** 仅增加轻量角色解析；不新增请求。更多原生图片迁移到 Next Image 后可获得既有优化能力。
+- **视觉风险:** 迁移面较广，需逐角色在酒红/素雅、浅色/深色、桌面/移动端检查。
+- **可维护性:** 圆角、背景和加载态从页面零散声明收敛到角色预设，减少双层 Wrapper 冲突。
+- **明确例外:** ImagePreview 主图/缩略图、popup QR、地图 SDK 资源保持专用实现。

--- a/openspec/changes/archive/2026-07-25-P-semantic-image-roles/proposal.md
+++ b/openspec/changes/archive/2026-07-25-P-semantic-image-roles/proposal.md
@@ -1,0 +1,48 @@
+# 全站图片语义角色与展示规范优化
+
+## 背景
+
+共享 `@wuh.site/components/image` 当前将统一的默认圆角、背景、边框、Skeleton 和错误态应用于所有图片 Wrapper。不同图片语义依赖页面级 `styled(Image)` 或内部 `style` 局部覆盖，导致 Wrapper 与内部图片的视觉职责混淆。
+
+已确认的可见问题包括：
+
+- 微信读书小尺寸封面受过大的通用圆角影响，实体书封轮廓被过度圆润。
+- About 页 GitHub 头像只对内部图片设置圆形，外层 Wrapper 仍保留默认背景和圆角，透明区域或加载状态会露出黑色/深色方底。
+- 文章头图、Logo、二维码、缩略图等场景存在双层圆角、透明背景不稳定或内部图片样式通道失效的问题。
+- Markdown、评论和足迹正文中的 HTML 图片没有统一遵循共享图片的内容图视觉规则。
+
+本次属于现有图片组件与页面展示的 **chore 优化**：一次性建立基于实际使用场景的图片角色体系，并迁移可安全治理的现有调用点。
+
+## 目标
+
+- 为共享 Image 增加 `avatar`、`book-cover`、`content`、`cover`、`thumbnail`、`logo`、`qr` 语义角色。
+- 明确 Wrapper 负责圆角、背景、边框、裁切、Skeleton 和 fallback，内部图片负责 object-fit、filter 和 transform。
+- 微信读书封面统一使用 2px 小圆角和中性纸张底色。
+- 头像统一使用圆形透明 Wrapper，不添加黑色、品牌色或纸张色底板。
+- Logo 使用 0 圆角透明外观，并提供稳定的内部图片 class/style 通道。
+- 内容图、页面封面、缩略图和二维码分别使用符合语义的视觉规则。
+- 一次性迁移现有可安全迁移的 React 图片调用，并规范 HTML 内容图片。
+- 保留未传 `role` 的兼容默认行为，在开发环境提示迁移，避免破坏未知消费者。
+
+## 非目标（明确不做）
+
+- 不改变图片源地址、上传流程、GitHub/微信读书数据或后端接口。
+- 不将 ImagePreview 主图和内部缩略图强制迁移到共享 Image。
+- 不处理地图 SDK 内部瓦片、marker 或媒体资源。
+- 不将微信分享独立 popup 文档中的原生二维码图片改为 React/Next Image。
+- 不重写 Markdown、评论和足迹 HTML 的渲染架构；仅统一其图片 CSS 视觉规范。
+- 不删除现有 `variant`、`appearance`、`borderRadius` 等覆盖属性。
+
+## 影响范围
+
+- `packages/components/image/index.tsx` — 增加语义角色解析、内部图片样式通道和兼容提示。
+- `packages/components/image/styles/index.tsx` — 按角色定义 Wrapper、Skeleton、fallback 和内部图片视觉。
+- `packages/components/image/readme.md` — 记录角色 API、覆盖优先级、迁移规则和例外。
+- `packages/wuh.site.next/app/HomeView.tsx`、`app/styles/index.ts` — 首页 Logo 与书封迁移。
+- `packages/wuh.site.next/app/weread/WereadView.tsx` — 微信读书封面迁移。
+- `packages/wuh.site.next/app/about/AboutView.tsx`、`app/about/styles.ts` — About 头像迁移并移除内部 style 修补。
+- `packages/wuh.site.next/app/post/components/`、`app/post/styles/` — 文章作者头像、评论头像、文章头图与内容 HTML 图片规范。
+- `packages/wuh.site.next/app/components/ContactCard.tsx` — Logo 与二维码迁移。
+- `packages/components/footprint-map/`、`packages/wuh.site.next/app/footprint/` — 足迹缩略图和内容 HTML 图片规范。
+- `packages/components/image-preview/` — 仅记录明确例外，不改变专用交互实现。
+- 影响包：`@wuh.site/components`、`@wuh.site/next`。

--- a/openspec/changes/archive/2026-07-25-P-semantic-image-roles/specs/components/spec.md
+++ b/openspec/changes/archive/2026-07-25-P-semantic-image-roles/specs/components/spec.md
@@ -1,26 +1,6 @@
-# Components — 组件包
+# Spec: 图片语义角色体系
 
-## MODIFIED
-
-### Requirement: 组件包使用 exports map 导出
-- **GIVEN** 消费者导入 `@wuh.site/components/flex`
-- **WHEN** 构建工具解析模块路径
-- **THEN** 通过 `exports` map 直接映射到对应子路径，无需桶文件
-
-### Requirement: 图片切换有过渡动画
-- **GIVEN** 用户在 ImagePreview 中切换到上一张或下一张
-- **WHEN** 图片 src 发生变化
-- **THEN** 旧图淡出并向切换反方向滑动，新图淡入并从切换方向滑入
-
-### Requirement: 缩放和旋转有弹性动画
-- **GIVEN** 用户点击缩放或旋转按钮
-- **WHEN** zoom 或 rotation 值变化
-- **THEN** 图片以 spring 动画过渡到新状态
-
-### Requirement: ImagePreview 组件代码按职责拆分
-- **GIVEN** ImagePreview 组件文件
-- **WHEN** 开发者查看代码
-- **THEN** types、hooks、Toolbar、MoreMenu、ThumbnailRail 各自独立文件，主组件不超过 500 行
+## ADDED
 
 ### Requirement: Image 支持语义角色
 - **GIVEN** 消费者使用共享 Image 渲染具有明确用途的图片
@@ -53,7 +33,7 @@
 - **GIVEN** Image role 为 `avatar`
 - **WHEN** 头像、Skeleton 或 fallback 渲染
 - **THEN** Wrapper 为 1:1 圆形并使用 cover
-- **AND** Wrapper 与默认失败态背景透明
+- **AND** Wrapper 背景透明且无默认黑色、品牌色或纸张色底板
 - **AND** 透明像素直接显示页面背景
 - **AND** flex 布局下头像不被压缩变形
 
@@ -63,19 +43,22 @@
 - **THEN** Wrapper 使用 2px 圆角和 contain
 - **AND** 使用中性纸张底色承载透明边缘
 - **AND** Skeleton 与加载失败状态保持书封形状
+- **AND** 首页和微信读书页允许保留不同尺寸
 
 ### Requirement: 内容图片具有稳定阅读外观
 - **GIVEN** Image role 为 `content` 或图片来自 Markdown、评论、足迹 HTML 内容
 - **WHEN** 图片渲染
 - **THEN** 图片最大宽度不超过内容容器且高度按比例自适应
 - **AND** 使用 8px 圆角、内容背景和轻边框
+- **AND** 透明 PNG 在浅色与深色主题下均可辨识
 - **AND** 窄屏不产生横向滚动
 
 ### Requirement: 页面封面圆角由上下文明确控制
 - **GIVEN** Image role 为 `cover`
 - **WHEN** 文章封面在桌面或移动端渲染
-- **THEN** 桌面圆角直接应用于 Image Wrapper
-- **AND** 移动端 edge-to-edge 场景将 Wrapper 圆角设为 0
+- **THEN** 使用 cover fit 和中性加载底
+- **AND** 桌面圆角直接应用于 Image Wrapper
+- **AND** 移动端 edge-to-edge 场景可将 Wrapper 圆角设为 0
 - **AND** 不存在父容器与内部 Wrapper 的双重冲突圆角
 
 ### Requirement: 缩略图使用紧凑状态
@@ -83,13 +66,14 @@
 - **WHEN** 足迹或普通媒体缩略图渲染
 - **THEN** 使用 cover、8px 圆角和调用方指定 ratio
 - **AND** 加载失败时使用不撑开布局的紧凑 fallback
+- **AND** 点击预览和键盘交互不因迁移改变
 
 ### Requirement: Logo 保持透明完整
 - **GIVEN** Image role 为 `logo`
 - **WHEN** SVG 或透明 Logo 渲染
 - **THEN** Wrapper 使用 0 圆角、透明背景、无边框和 contain
 - **AND** 默认关闭 Skeleton
-- **AND** 默认失败态保持透明
+- **AND** 不裁切透明边缘
 - **AND** 暗色模式 filter 可通过内部图片样式通道稳定生效
 
 ### Requirement: 二维码保持可扫描性
@@ -97,9 +81,10 @@
 - **WHEN** 二维码在浅色或深色主题下渲染
 - **THEN** 使用 1:1、contain、2px 圆角和白色背景
 - **AND** 保留足够白色静区
+- **AND** 不因 cover 裁切、透明背景或主题底色降低扫码对比度
 
 ### Requirement: 专用图片链路保持例外
 - **GIVEN** 图片属于 ImagePreview 主图/内部缩略图、微信分享 popup 或地图 SDK 资源
-- **WHEN** 图片角色迁移执行
+- **WHEN** 本次图片角色迁移执行
 - **THEN** 保留其专用原生图片实现
-- **AND** 不引入会破坏专用交互的共享 Wrapper
+- **AND** 不引入会破坏缩放、旋转、拖动、按钮动画或 SDK 行为的共享 Wrapper

--- a/openspec/changes/archive/2026-07-25-P-semantic-image-roles/tasks.md
+++ b/openspec/changes/archive/2026-07-25-P-semantic-image-roles/tasks.md
@@ -1,0 +1,141 @@
+# 任务清单
+
+> 本清单仅描述后续实施工作。当前 propose 阶段不修改产品代码。
+
+## Phase 1: 共享 Image 角色基础
+
+### Task 1: 建立角色 API 与失败契约
+
+- [ ] **文件:** `packages/components/image/index.tsx`、`packages/components/image/styles/index.tsx`、相关测试
+- [ ] 先增加失败测试，覆盖 `ImageRole`、角色默认值、显式属性优先级和兼容默认行为
+- [ ] 增加 `imageClassName`、`imageStyle` 的失败测试，确认其只作用于内部图片
+- [ ] 增加开发环境无 role 提示和生产环境静默的契约
+- [ ] **预计耗时:** 1.5 小时
+- [ ] **实际耗时:** 待实施
+- [ ] **验证:** 相关测试先 RED，最小实现后 GREEN
+
+### Task 2: 实现角色 resolver 与状态视觉
+
+- [ ] **文件:** `packages/components/image/index.tsx`、`packages/components/image/styles/index.tsx`
+- [ ] 实现 avatar/book-cover/content/cover/thumbnail/logo/qr 默认配置
+- [ ] 确保 Wrapper 单点负责圆角、背景、边框和裁切
+- [ ] 让 Skeleton 和 fallback 继承角色形状，并为小尺寸角色提供紧凑错误态
+- [ ] 保持显式 `borderRadius`、`appearance`、`variant` 高于 role
+- [ ] 保留未传 role 的兼容默认值
+- [ ] **预计耗时:** 2 小时
+- [ ] **实际耗时:** 待实施
+- [ ] **验证:** 组件测试通过；类型检查通过
+
+### Task 3: 更新 Image 文档
+
+- [ ] **文件:** `packages/components/image/readme.md`
+- [ ] 记录角色表、属性优先级、Wrapper/内部图片职责和迁移示例
+- [ ] 记录 ImagePreview、popup QR、地图 SDK 等例外
+- [ ] **预计耗时:** 45 分钟
+- [ ] **实际耗时:** 待实施
+- [ ] **验证:** 文档无 TBD/TODO；示例与类型一致
+
+## Phase 2: 高优先级页面迁移
+
+### Task 4: 迁移头像角色
+
+- [ ] **文件:** `packages/wuh.site.next/app/about/AboutView.tsx`、`app/about/styles.ts`、`app/post/components/PostHeader.tsx`、`app/post/styles/post-header.ts`、`app/post/components/PostComments.tsx`
+- [ ] 先增加失败测试，锁定圆形 Wrapper、透明背景和首字母 fallback
+- [ ] About 头像移除内部 inline 圆角修补，使用 `role='avatar'`
+- [ ] 文章作者头像迁移并保留 accent ring
+- [ ] 评论头像迁移并保留无图片首字母显示
+- [ ] **预计耗时:** 1.5 小时
+- [ ] **实际耗时:** 待实施
+- [ ] **验证:** 头像在浅色/深色均无黑底，Skeleton/fallback 保持圆形
+
+### Task 5: 迁移书封角色
+
+- [ ] **文件:** `packages/wuh.site.next/app/HomeView.tsx`、`app/styles/index.ts`、`app/weread/WereadView.tsx`
+- [ ] 先增加失败测试，锁定 `book-cover`、2px 圆角、contain 和中性纸张底
+- [ ] 两处书封删除重复的 4px 圆角、appearance 和 variant 配置
+- [ ] 保留调用方尺寸、flex 和必要的局部阴影差异
+- [ ] **预计耗时:** 1 小时
+- [ ] **实际耗时:** 待实施
+- [ ] **验证:** 首页与微信读书页封面视觉一致且无过大圆角
+
+### Task 6: 迁移 Logo 与二维码
+
+- [ ] **文件:** `packages/wuh.site.next/app/HomeView.tsx`、`app/styles/index.ts`、`app/components/ContactCard.tsx`
+- [ ] 先增加失败测试，锁定 logo 0 圆角透明外观和 QR 白底静区
+- [ ] 首页 Logo 使用 role 与正式 `imageClassName`/`imageStyle`
+- [ ] ContactCard Logo 迁移到 logo role
+- [ ] ContactCard QR 迁移到 qr role，使用 contain 而非 cover
+- [ ] **预计耗时:** 1.25 小时
+- [ ] **实际耗时:** 待实施
+- [ ] **验证:** Logo 暗色 filter 生效；二维码在两种显示模式下保持可扫描
+
+## Phase 3: 封面、缩略图与 HTML 内容
+
+### Task 7: 迁移文章封面
+
+- [ ] **文件:** `packages/wuh.site.next/app/post/components/PostCover.tsx`、`app/post/styles/post-header.ts`
+- [ ] 先增加失败测试，复现移动端父容器 0 圆角但 Image Wrapper 仍有默认圆角的问题
+- [ ] 使用 cover role，让桌面和移动圆角都落在 Wrapper
+- [ ] 保留 priority、16:9、edge-to-edge 和加载失败隐藏行为
+- [ ] **预计耗时:** 1.25 小时
+- [ ] **实际耗时:** 待实施
+- [ ] **验证:** 320px 移动端封面真实直角；桌面按页面规范显示圆角
+
+### Task 8: 迁移足迹缩略图
+
+- [ ] **文件:** `packages/components/footprint-map/`、`packages/wuh.site.next/app/footprint/page.tsx`
+- [ ] 先增加失败测试，锁定 1:1、cover、8px 和点击预览行为
+- [ ] 将可安全的足迹照片迁移到 thumbnail role
+- [ ] 不改变地图容器或 SDK 资源
+- [ ] **预计耗时:** 1 小时
+- [ ] **实际耗时:** 待实施
+- [ ] **验证:** 图片布局、点击预览和键盘行为保持不变
+
+### Task 9: 统一 HTML 内容图片 CSS
+
+- [ ] **文件:** `packages/wuh.site.next/app/post/styles/post-markdown.ts`、评论样式、`app/footprint/` 内容样式
+- [ ] 增加源码/视觉契约，锁定 max-width、height:auto、8px、背景和轻边框
+- [ ] 让 Markdown、评论 HTML 和足迹正文图片与 content role 视觉一致
+- [ ] 防止窄屏横向滚动
+- [ ] **预计耗时:** 1 小时
+- [ ] **实际耗时:** 待实施
+- [ ] **验证:** 含透明 PNG 和超宽图片的 HTML 内容在 320px 下可读
+
+## Phase 4: 回归与视觉验收
+
+### Task 10: 完整质量门禁
+
+- [ ] **文件:** 本次所有变更
+- [ ] 运行 Image 组件与页面相关测试
+- [ ] 运行 Oxlint
+- [ ] 运行 Next TypeScript 检查
+- [ ] 运行 Next 构建
+- [ ] 运行 `git diff --check`
+- [ ] **预计耗时:** 1.25 小时
+- [ ] **实际耗时:** 待实施
+- [ ] **验证:** 所有命令零错误；若环境阻塞需记录根因而非绕过
+
+### Task 11: 浏览器矩阵验收
+
+- [ ] **页面:** `/`、`/weread`、`/about`、文章详情、足迹页、Contact Dialog
+- [ ] 检查酒红/素雅 × 跟随系统/浅色/深色
+- [ ] 检查 320px、375px、768px、1280px
+- [ ] 检查透明头像、书封、Logo、内容图、文章封面、缩略图和二维码
+- [ ] 检查加载中、加载失败、减少动效和图片预览交互
+- [ ] **预计耗时:** 1.5 小时
+- [ ] **实际耗时:** 待实施
+- [ ] **验证:** 无黑底、无双层圆角、无布局跳动、无横向滚动
+
+## 验收
+
+- [ ] 微信读书首页与列表书封均使用 2px 圆角
+- [ ] About、文章作者和评论头像透明区域不显示黑底
+- [ ] 头像 Skeleton/fallback 始终为圆形
+- [ ] 首页与 ContactCard Logo 为 0 圆角透明外观，内部 filter 稳定生效
+- [ ] 文章封面移动端为真实直角，桌面圆角由 Wrapper 单点负责
+- [ ] 足迹缩略图保持 1:1、cover 和点击预览
+- [ ] 二维码在所有主题下保持白底、静区和可扫描性
+- [ ] HTML 内容图片不超出容器且与 content role 视觉一致
+- [ ] ImagePreview、popup QR、地图 SDK 专用实现未被误改
+- [ ] 未传 role 的旧消费者继续运行，开发环境提示迁移
+- [ ] 相关测试、Lint、TypeScript、构建与 `git diff --check` 全部通过

--- a/packages/components/footprint-map/styles.ts
+++ b/packages/components/footprint-map/styles.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import styled from 'styled-components';
+import Image from '@wuh.site/components/image';
 
 export const MapContainer = styled.div<{ $height?: string }>`
   width: 100%;
@@ -63,12 +64,24 @@ export const PhotoGrid = styled.div`
   gap: 8px;
 `;
 
-export const Photo = styled.img`
+export const Photo = styled(Image)`
   width: 100%;
   aspect-ratio: 1;
-  object-fit: cover;
-  border-radius: 8px;
   cursor: pointer;
+`;
+
+export const HtmlContent = styled.div`
+  line-height: 1.75;
+  font-size: 0.9375rem;
+
+  img {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    border-radius: 8px;
+    border: 1px solid rgba(0, 0, 0, 0.06);
+    background: var(--background-100);
+  }
 `;
 
 export const EmptyPanel = styled.div`

--- a/packages/components/image/index.tsx
+++ b/packages/components/image/index.tsx
@@ -17,10 +17,32 @@ type NativeImageProps = React.ComponentPropsWithoutRef<typeof NextImage>
 
 export type { ImageVariant, ImageAppearance }
 
+export type ImageRole = 'avatar' | 'book-cover' | 'content' | 'cover' | 'thumbnail' | 'logo' | 'qr'
 type AspectRatio = number | `${number}:${number}`
+
+type RolePreset = {
+  borderRadius: string
+  appearance: ImageAppearance
+  variant: ImageVariant
+  showSkeleton?: boolean
+  compactFallback?: boolean
+}
+
+const ROLE_PRESETS: Record<ImageRole, RolePreset> = {
+  avatar: { borderRadius: '50%', appearance: 'plain', variant: 'cover', compactFallback: true },
+  'book-cover': { borderRadius: '2px', appearance: 'default', variant: 'contain', compactFallback: true },
+  content: { borderRadius: '8px', appearance: 'default', variant: 'contain' },
+  cover: { borderRadius: 'var(--radius-card, 12px)', appearance: 'default', variant: 'cover' },
+  thumbnail: { borderRadius: '8px', appearance: 'default', variant: 'cover', compactFallback: true },
+  logo: { borderRadius: '0', appearance: 'plain', variant: 'contain', showSkeleton: false, compactFallback: true },
+  qr: { borderRadius: '2px', appearance: 'qr', variant: 'contain', compactFallback: true },
+}
 
 export interface ImageProps extends Omit<NativeImageProps, 'className' | 'style' | 'onLoad' | 'onError'> {
   className?: string
+  imageClassName?: string
+  imageStyle?: React.CSSProperties
+  role?: ImageRole
   variant?: ImageVariant
   ratio?: AspectRatio
   borderRadius?: string | number
@@ -44,31 +66,34 @@ function parseRatio(ratio?: AspectRatio): number | undefined {
   if (!ratio) return undefined
   if (typeof ratio === 'number') return ratio > 0 ? ratio : undefined
   if (ratio.includes(':')) {
-    const [w, h] = ratio.split(':').map(Number)
-    return Number.isFinite(w) && Number.isFinite(h) && h !== 0 ? w / h : undefined
+    const [width, height] = ratio.split(':').map(Number)
+    return Number.isFinite(width) && Number.isFinite(height) && height !== 0 ? width / height : undefined
   }
   const numeric = Number(ratio)
   return Number.isFinite(numeric) && numeric > 0 ? numeric : undefined
 }
 
-const DefaultFallback = () => (
-  <Fallback role='alert' aria-live='polite'>
+const DefaultFallback = ({ compact, appearance }: { compact: boolean; appearance: ImageAppearance }) => (
+  <Fallback role='alert' aria-live='polite' $compactFallback={compact} $appearance={appearance}>
     <IconFallbackImage />
-    <span>图片加载失败</span>
+    {!compact && <span>图片加载失败</span>}
   </Fallback>
 )
 
 const Image = React.forwardRef<HTMLImageElement, ImageProps>((props, ref) => {
   const {
-    variant = 'cover',
+    role,
+    variant,
     ratio,
     borderRadius,
-    showSkeleton = true,
+    showSkeleton,
     skeleton,
     errorFallback,
     className,
+    imageClassName,
+    imageStyle,
     inline = false,
-    appearance = 'default',
+    appearance,
     lazy = true,
     rootMargin = '200px',
     onStatusChange,
@@ -84,14 +109,18 @@ const Image = React.forwardRef<HTMLImageElement, ImageProps>((props, ref) => {
     ...restNativeProps
   } = props
 
+  const preset = role ? ROLE_PRESETS[role] : undefined
+  const resolvedVariant = variant ?? preset?.variant ?? 'cover'
+  const resolvedAppearance = appearance ?? preset?.appearance ?? 'default'
+  const resolvedShowSkeleton = showSkeleton ?? preset?.showSkeleton ?? true
+  const compactFallback = preset?.compactFallback ?? false
+  const resolvedRadius = formatRadius(borderRadius ?? preset?.borderRadius)
   const ratioValue = React.useMemo(() => parseRatio(ratio), [ratio])
-  const resolvedRadius = React.useMemo(() => formatRadius(borderRadius), [borderRadius])
   const finalFill = ratioValue ? true : fill
   const finalWidth = ratioValue ? undefined : width
   const finalHeight = ratioValue ? undefined : height
   const hasExplicitSize = typeof finalWidth !== 'undefined' && typeof finalHeight !== 'undefined'
   const shouldStretch = Boolean(finalFill)
-
   const shouldLazy = lazy && !priority
 
   const [inView, setInView] = React.useState(!shouldLazy)
@@ -99,22 +128,26 @@ const Image = React.forwardRef<HTMLImageElement, ImageProps>((props, ref) => {
   const [skipLazy, setSkipLazy] = React.useState(false)
   const wrapperRef = React.useRef<HTMLDivElement>(null)
 
-  // prefers-reduced-motion → skip lazy loading
   React.useEffect(() => {
-    const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
-    if (mq.matches) { setSkipLazy(true); setInView(true) }
-    const handler = (e: MediaQueryListEvent) => {
-      if (e.matches) { setSkipLazy(true); setInView(true) }
+    if (process.env.NODE_ENV !== 'production' && !role) {
+      console.warn('[Image] Add a semantic role to this image.')
     }
-    mq.addEventListener('change', handler)
-    return () => mq.removeEventListener('change', handler)
+  }, [role])
+
+  React.useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)')
+    if (mediaQuery.matches) { setSkipLazy(true); setInView(true) }
+    const handler = (event: MediaQueryListEvent) => {
+      if (event.matches) { setSkipLazy(true); setInView(true) }
+    }
+    mediaQuery.addEventListener('change', handler)
+    return () => mediaQuery.removeEventListener('change', handler)
   }, [])
 
-  // IntersectionObserver lazy loading
   React.useEffect(() => {
     if (!shouldLazy || skipLazy || inView) return
-    const el = wrapperRef.current
-    if (!el) return
+    const element = wrapperRef.current
+    if (!element) return
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {
@@ -124,32 +157,23 @@ const Image = React.forwardRef<HTMLImageElement, ImageProps>((props, ref) => {
       },
       { rootMargin }
     )
-    observer.observe(el)
+    observer.observe(element)
     return () => observer.disconnect()
   }, [shouldLazy, skipLazy, inView, rootMargin])
 
-  // src 变化时重置状态
   React.useEffect(() => {
-    if (inView) {
-      setStatus(showSkeleton ? 'visible' : 'idle')
-    } else {
-      setStatus('idle')
-    }
-  }, [src])
+    setStatus(inView ? (resolvedShowSkeleton ? 'visible' : 'idle') : 'idle')
+  }, [src, inView, resolvedShowSkeleton])
+
   React.useEffect(() => {
-    if (inView && status === 'idle') {
-      setStatus('visible')
-    }
+    if (inView && status === 'idle') setStatus('visible')
   }, [inView, status])
 
   React.useEffect(() => {
     onStatusChange?.(status)
   }, [status, onStatusChange])
 
-  const handleLoad = React.useCallback(() => {
-    setStatus('loaded')
-  }, [])
-
+  const handleLoad = React.useCallback(() => setStatus('loaded'), [])
   const handleError = React.useCallback(
     (event: Parameters<NonNullable<ImageProps['onError']>>[0]) => {
       setStatus('error')
@@ -158,7 +182,7 @@ const Image = React.forwardRef<HTMLImageElement, ImageProps>((props, ref) => {
     [onError]
   )
 
-  const showSkel = showSkeleton && status !== 'loaded' && status !== 'error'
+  const showSkel = resolvedShowSkeleton && status !== 'loaded' && status !== 'error'
   const showError = status === 'error'
 
   return (
@@ -166,9 +190,10 @@ const Image = React.forwardRef<HTMLImageElement, ImageProps>((props, ref) => {
       ref={wrapperRef}
       className={className}
       $inline={inline}
-      $appearance={appearance}
+      $appearance={resolvedAppearance}
       $radius={resolvedRadius}
       $hasExplicitSize={hasExplicitSize}
+      $role={role}
       style={ratioValue ? { aspectRatio: String(ratioValue) } : undefined}
     >
       {showSkel && (skeleton ?? <Skeleton $visible={status === 'idle' || status === 'visible'} />)}
@@ -177,6 +202,8 @@ const Image = React.forwardRef<HTMLImageElement, ImageProps>((props, ref) => {
         <ImgWrapper
           {...restNativeProps}
           ref={ref}
+          className={imageClassName}
+          style={imageStyle}
           src={src}
           alt={alt}
           fill={finalFill}
@@ -185,7 +212,7 @@ const Image = React.forwardRef<HTMLImageElement, ImageProps>((props, ref) => {
           sizes={sizes}
           priority={priority}
           loading={loading}
-          $objectFit={variant}
+          $objectFit={resolvedVariant}
           $status={status === 'loaded' ? 'loaded' : 'visible'}
           $stretch={shouldStretch}
           onLoad={handleLoad}
@@ -193,7 +220,7 @@ const Image = React.forwardRef<HTMLImageElement, ImageProps>((props, ref) => {
         />
       )}
 
-      {showError && (errorFallback ?? <DefaultFallback />)}
+      {showError && (errorFallback ?? <DefaultFallback compact={compactFallback} appearance={resolvedAppearance} />)}
     </Wrapper>
   )
 })

--- a/packages/components/image/readme.md
+++ b/packages/components/image/readme.md
@@ -1,42 +1,59 @@
 ## Image 图片组件
 
-基于 Next.js `next/image` 的 UI 包装，提供统一的加载骨架、错误兜底、宽高比、说明文案与 overlay 能力。
+基于 Next.js `next/image` 的 UI 包装，统一加载骨架、错误兜底、宽高比与语义化图片外观。
 
-### 使用示例
+### 语义角色
+
+优先通过 `role` 表达用途，组件会统一处理 Wrapper 圆角、背景、边框、裁切和状态外观。
+
+| Role | 圆角 | 背景 | object-fit | 用途 |
+| --- | --- | --- | --- | --- |
+| `avatar` | 50% | 透明 | cover | 人物头像 |
+| `book-cover` | 2px | 中性纸张色 | contain | 小尺寸书封 |
+| `content` | 8px | 内容背景 | contain | 正文图片 |
+| `cover` | 12px，可覆盖 | 中性加载底 | cover | 文章/页面封面 |
+| `thumbnail` | 8px | 中性底 | cover | 媒体缩略图 |
+| `logo` | 0 | 透明 | contain | Logo 与透明 SVG |
+| `qr` | 2px | 白色静区 | contain | 二维码 |
 
 ```tsx
-import Image from '@wuh.site/components/image'
-
-export default function Demo() {
-  return (
-    <Image
-      src="https://images.unsplash.com/photo-1503264116251-35a269479413"
-      alt="Mountains"
-      ratio="16:9"
-      priority
-      overlay={<span>© Unsplash</span>}
-      caption="夏季山景，自动铺满容器且默认 lazy loading。"
-    />
-  )
-}
+<Image role='avatar' src={avatarUrl} alt='用户头像' width={56} height={56} />
+<Image role='book-cover' src={coverUrl} alt='书名' width={40} height={54} />
+<Image role='logo' imageClassName='brand-logo' src='/logo.svg' alt='wuh.site' width={64} height={38} />
 ```
+
+属性优先级：
+
+```text
+显式 borderRadius / appearance / variant > role 预设 > 兼容默认值
+```
+
+未传 `role` 时暂时保持原默认行为，开发环境会提示迁移。
+
+### Wrapper 与内部图片
+
+- `className` 作用于 Wrapper，适合尺寸、布局、圆角和阴影。
+- `imageClassName`、`imageStyle` 只作用于内部 Next Image，适合 filter、transform 等像素样式。
+- Skeleton 和 fallback 继承 Wrapper 外轮廓。
+- ImagePreview 主图/缩略图、独立 popup 图片和地图 SDK 资源保留专用实现。
 
 ### Props
 
 | 名称 | 类型 | 默认值 | 说明 |
 | --- | --- | --- | --- |
-| `variant` | `'cover' \| 'contain' \| 'fill' \| 'scale-down' \| 'none'` | `'cover'` | 控制 `object-fit` 行为 |
-| `ratio` | `number \| \`\${number}:\${number}\`` | `undefined` | 设定宽高比（如 `16:9`），内部自动使用 `fill` 布局 |
-| `borderRadius` | `string \| number` | `var(--border-radius-lg, 16px)` | 圆角 |
-| `showSkeleton` | `boolean` | `true` | 是否展示加载骨架 |
-| `skeleton` | `ReactNode` | - | 自定义骨架节点 |
-| `errorFallback` | `ReactNode` | 默认插画 | 加载失败兜底内容 |
-| `caption` | `ReactNode` | - | 图注文字，渲染在下方 |
-| `overlay` | `ReactNode` | - | 覆盖在图片上的层，可用于显示版权/操作 |
-| `disableTransition` | `boolean` | `false` | 关闭加载完成时的淡入/缩放动画 |
-| `inline` | `boolean` | `false` | 以内联模式渲染，适用于按钮/文字内部 |
-| `appearance` | `'default' \| 'plain'` | `default` | `plain` 将移除边框与背景，适合 Logo/图标场景 |
-| `onStatusChange` | `(status: 'loading' \| 'loaded' \| 'error') => void` | - | 状态变化回调 |
-| `wrapperStyle` / `imageStyle` | `CSSProperties` | - | 分别作用于外层 `figure` 与 Next Image |
+| `role` | `ImageRole` | `undefined` | 图片语义角色 |
+| `variant` | `'cover' \| 'contain' \| 'fill'` | role 或 `'cover'` | `object-fit` |
+| `ratio` | `number \| \`${number}:${number}\`` | `undefined` | 宽高比，设置后使用 fill 布局 |
+| `borderRadius` | `string \| number` | role 或 16px | Wrapper 圆角 |
+| `showSkeleton` | `boolean` | role 或 `true` | 是否显示加载骨架 |
+| `skeleton` | `ReactNode` | - | 自定义骨架 |
+| `errorFallback` | `ReactNode` | 默认兜底 | 自定义错误内容 |
+| `inline` | `boolean` | `false` | Wrapper 使用 inline-block |
+| `appearance` | `'default' \| 'plain' \| 'qr'` | role 或 `default` | Wrapper 背景与边框 |
+| `imageClassName` | `string` | - | 内部图片 class |
+| `imageStyle` | `CSSProperties` | - | 内部图片样式 |
+| `lazy` | `boolean` | `true` | 是否启用 IntersectionObserver 懒加载 |
+| `rootMargin` | `string` | `200px` | 懒加载提前量 |
+| `onStatusChange` | `(status) => void` | - | 状态变化回调 |
 
-其余 props 透传给 `next/image`，例如 `src`, `alt`, `width`, `height`, `fill`, `sizes`, `loading`, `priority` 等。
+其余属性透传给 `next/image`，包括 `src`、`alt`、`width`、`height`、`fill`、`sizes`、`loading` 和 `priority`。

--- a/packages/components/image/styles/index.tsx
+++ b/packages/components/image/styles/index.tsx
@@ -3,9 +3,11 @@
 import NextImage from 'next/image'
 import styled, { css, keyframes } from 'styled-components'
 
+import type { ImageRole } from '../index'
+
 export type ImageStatus = 'idle' | 'visible' | 'loaded' | 'error'
 export type ImageVariant = 'cover' | 'contain' | 'fill'
-export type ImageAppearance = 'default' | 'plain'
+export type ImageAppearance = 'default' | 'plain' | 'qr'
 
 const shimmer = keyframes`
   0% { background-position: 200% 0; }
@@ -17,13 +19,23 @@ export const Wrapper = styled.div<{
   $appearance: ImageAppearance
   $radius: string
   $hasExplicitSize: boolean
+  $role: ImageRole | undefined
 }>`
   display: ${(p) => (p.$inline ? 'inline-block' : 'block')};
   position: relative;
   overflow: hidden;
   border-radius: ${(p) => p.$radius};
-  background-color: ${(p) => (p.$appearance === 'default' ? 'var(--background-200, #f5f5f5)' : 'transparent')};
-  border: ${(p) => (p.$appearance === 'default' ? '1px solid var(--normal-200, rgba(15, 23, 42, 0.08))' : 'none')};
+  background-color: ${(p) => {
+    if (p.$appearance === 'plain') return 'transparent'
+    if (p.$appearance === 'qr') return '#fff'
+    if (p.$role === 'book-cover') return 'color-mix(in oklab, var(--background-100, #fff) 92%, #d8cdbf 8%)'
+    return 'var(--background-200, #f5f5f5)'
+  }};
+  border: ${(p) => {
+    if (p.$appearance === 'plain') return 'none'
+    if (p.$appearance === 'qr') return '6px solid #fff'
+    return '1px solid var(--normal-200, rgba(15, 23, 42, 0.08))'
+  }};
   isolation: isolate;
   color: var(--text-secondary, #475467);
   width: ${(p) => (p.$hasExplicitSize ? undefined : '100%')};
@@ -54,6 +66,7 @@ export const ImgWrapper = styled(NextImage)<{
 export const Skeleton = styled.div<{ $visible: boolean }>`
   position: absolute;
   inset: 0;
+  border-radius: inherit;
   background: linear-gradient(90deg, rgba(0, 0, 0, 0.04) 0%, rgba(0, 0, 0, 0.08) 50%, rgba(0, 0, 0, 0.04) 100%);
   background-size: 400% 100%;
   animation: ${shimmer} 1.6s ease-in-out infinite;
@@ -66,16 +79,17 @@ export const Skeleton = styled.div<{ $visible: boolean }>`
   }
 `
 
-export const Fallback = styled.div`
+export const Fallback = styled.div<{ $compactFallback: boolean; $appearance: ImageAppearance }>`
   position: absolute;
   inset: 0;
+  border-radius: inherit;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: ${(p) => (p.$compactFallback ? '0' : '8px')};
   text-align: center;
-  padding: 16px;
+  padding: ${(p) => (p.$compactFallback ? '4px' : '16px')};
   color: var(--text-secondary, #475467);
-  background-color: var(--background-100, #fff);
+  background-color: ${(p) => (p.$appearance === 'plain' ? 'transparent' : p.$appearance === 'qr' ? '#fff' : 'var(--background-100, #fff)')};
 `

--- a/packages/components/test/image-role-contract.test.mjs
+++ b/packages/components/test/image-role-contract.test.mjs
@@ -1,0 +1,59 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const testDir = dirname(fileURLToPath(import.meta.url))
+const packageRoot = resolve(testDir, '..')
+const imageSource = await readFile(resolve(packageRoot, 'image/index.tsx'), 'utf8')
+const stylesSource = await readFile(resolve(packageRoot, 'image/styles/index.tsx'), 'utf8')
+
+const roles = ['avatar', 'book-cover', 'content', 'cover', 'thumbnail', 'logo', 'qr']
+
+test('Image 声明完整语义角色集合', () => {
+  assert.match(imageSource, /export type ImageRole/)
+  for (const role of roles) assert.match(imageSource, new RegExp(`'${role}'`))
+  assert.match(imageSource, /role\?: ImageRole/)
+})
+
+test('角色 resolver 使用显式属性覆盖角色默认值', () => {
+  assert.match(imageSource, /ROLE_PRESETS/)
+  assert.match(imageSource, /borderRadius \?\? preset\?\.borderRadius/)
+  assert.match(imageSource, /appearance \?\? preset\?\.appearance/)
+  assert.match(imageSource, /variant \?\? preset\?\.variant/)
+})
+
+test('Image 为内部图片提供 className 和 style 通道', () => {
+  assert.match(imageSource, /imageClassName\?: string/)
+  assert.match(imageSource, /imageStyle\?: React\.CSSProperties/)
+  assert.match(imageSource, /className=\{imageClassName\}/)
+  assert.match(imageSource, /style=\{imageStyle\}/)
+})
+
+test('未传 role 时保留兼容默认值并仅在开发环境提示', () => {
+  assert.match(imageSource, /process\.env\.NODE_ENV !== 'production'/)
+  assert.match(imageSource, /!role/)
+  assert.match(imageSource, /console\.warn/)
+  assert.match(imageSource, /var\(--border-radius-lg, 16px\)/)
+})
+
+test('角色视觉由 Wrapper 和状态层统一承载', () => {
+  assert.match(stylesSource, /\$role: ImageRole \| undefined/)
+  assert.match(stylesSource, /\$compactFallback/)
+  assert.match(stylesSource, /border-radius:\s*inherit/)
+  assert.match(stylesSource, /prefers-reduced-motion:\s*reduce/)
+})
+
+test('plain 角色的默认错误态保持透明背景', () => {
+  assert.match(imageSource, /<DefaultFallback compact=\{compactFallback\} appearance=\{resolvedAppearance\}/)
+  assert.match(stylesSource, /\$appearance: ImageAppearance/)
+  assert.match(stylesSource, /p\.\$appearance === 'plain' \? 'transparent'/)
+})
+
+test('角色预设符合已确认视觉基线', () => {
+  assert.match(imageSource, /'book-cover':[\s\S]*borderRadius: '2px'[\s\S]*variant: 'contain'/)
+  assert.match(imageSource, /avatar:[\s\S]*borderRadius: '50%'[\s\S]*appearance: 'plain'/)
+  assert.match(imageSource, /logo:[\s\S]*borderRadius: '0'[\s\S]*appearance: 'plain'/)
+  assert.match(imageSource, /qr:[\s\S]*borderRadius: '2px'[\s\S]*variant: 'contain'/)
+})

--- a/packages/wuh.site.next/app/HomeView.tsx
+++ b/packages/wuh.site.next/app/HomeView.tsx
@@ -102,7 +102,7 @@ export default function HomeView({ repos, posts, yearlySummaries, wereadBooks }:
     <S.Root>
       <S.Main>
         <S.Hero>
-          <S.StyledLogo src='/logo.svg' alt='wuh.site.logo' width={64} height={38.4} priority />
+          <S.StyledLogo role='logo' src='/logo.svg' alt='wuh.site.logo' width={64} height={38.4} priority />
           <S.SiteTitle>wuh.site&nbsp;&middot;&nbsp;朝朝如念</S.SiteTitle>
           <S.SiteTagline>雾失楼台，月迷津渡</S.SiteTagline>
         </S.Hero>
@@ -204,7 +204,7 @@ export default function HomeView({ repos, posts, yearlySummaries, wereadBooks }:
               <S.BooksList>
                 {wereadBooks.map((book) => (
                   <S.BookRow key={book.bookId}>
-                    <S.BookCover src={book.cover || ''} alt={book.title} width={36} height={54} />
+                    <S.BookCover role='book-cover' src={book.cover || ''} alt={book.title} width={36} height={54} />
                     <S.BookInfo>
                       <S.BookTitle>{book.title}</S.BookTitle>
                       <S.BookMeta>{book.author}{book.finishReading ? ' · 已读完' : ' · 阅读中'}</S.BookMeta>

--- a/packages/wuh.site.next/app/about/AboutView.tsx
+++ b/packages/wuh.site.next/app/about/AboutView.tsx
@@ -103,9 +103,10 @@ const AboutView = ({ profile, repos: _ }: AboutViewProps) => {
                     <Image
                       src={avatarUrl || ''}
                       alt={name}
+                      role='avatar'
                       width={56}
                       height={56}
-                      style={{ borderRadius: '50%', objectFit: 'cover', flexShrink: 0 }}
+                      imageStyle={{ flexShrink: 0 }}
                     />
                   </ProfileAvatarLink>
                 ) : (

--- a/packages/wuh.site.next/app/components/ContactCard.tsx
+++ b/packages/wuh.site.next/app/components/ContactCard.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from 'react'
 import styled from '@wuh.site/components/styled'
 import Button from '@wuh.site/components/button'
+import Image from '@wuh.site/components/image'
 
 import ImagePreview, { type ImagePreviewItem } from '@wuh.site/components/image-preview'
 import { IconGithub, IconTwitter, IconDouban, IconMusic, IconDiscord } from '@wuh.site/components/icons'
@@ -71,11 +72,9 @@ const ActionArea = styled(Button).attrs({ variant: "outlined", color: "secondary
   }
 `
 
-const QRImage = styled.img`
+const QRImage = styled(Image)`
   width: 184px;
   height: 184px;
-  object-fit: cover;
-  border-radius: calc(var(--radius-card) - 4px);
 `
 
 const LinkButton = styled.a`
@@ -120,14 +119,18 @@ const Header = styled.div`
   gap: var(--space-sm);
 `
 
-const Avatar = styled.img`
+const Avatar = styled(Image)`
   width: 48px;
   height: auto;
-  border-radius: 4px;
   flex-shrink: 0;
 
+  .contact-logo {
+    width: 48px;
+    height: auto;
+  }
+
   @media (prefers-color-scheme: dark) {
-    filter: invert(1);
+    .contact-logo { filter: invert(1); }
   }
 `
 
@@ -245,7 +248,7 @@ const ContactCard = ({
             aria-label={hasLink ? `前往 ${badge}` : `查看 ${badge} 二维码`}
             onClick={hasQR ? () => setPreviewOpen(true) : undefined}
           >
-            {hasQR && <QRImage src={qrSrc} alt={`${name} 的 ${badge} 二维码`} />}
+            {hasQR && <QRImage role='qr' src={qrSrc} alt={`${name} 的 ${badge} 二维码`} width={184} height={184} />}
             {hasLink && (
               <LinkButton as='span'>
                 <LinkIcon>{linkIconMap[badge]}</LinkIcon>
@@ -255,7 +258,7 @@ const ContactCard = ({
           </ActionArea>
           <Info>
             <Header>
-              <Avatar src='/logo.svg' alt='wuh.site' />
+              <Avatar role='logo' imageClassName='contact-logo' src='/logo.svg' alt='wuh.site' width={48} height={29} />
               <NameBlock>
                 <Name>{name}</Name>
                 <Handle>{handle}</Handle>

--- a/packages/wuh.site.next/app/footprint/page.tsx
+++ b/packages/wuh.site.next/app/footprint/page.tsx
@@ -19,6 +19,7 @@ import {
   PlaceDate,
   PhotoGrid,
   Photo,
+  HtmlContent,
   EmptyPanel,
 } from '@wuh.site/components/footprint-map/styles'
 
@@ -78,11 +79,13 @@ export default function FootprintPage() {
                   <PhotoGrid>
                     {selected.photos.map((url, i) => (
                       <Photo
+                        role='thumbnail'
                         key={i}
                         src={url}
                         alt={selected.name}
+                        width={160}
+                        height={160}
                         onClick={() => handlePhotoClick(i)}
-                        loading="lazy"
                       />
                     ))}
                   </PhotoGrid>
@@ -104,10 +107,7 @@ export default function FootprintPage() {
               )}
 
               {selected.content && (
-                <div
-                  style={{ lineHeight: 1.75, fontSize: '0.9375rem' }}
-                  dangerouslySetInnerHTML={{ __html: selected.content }}
-                />
+                <HtmlContent dangerouslySetInnerHTML={{ __html: selected.content }} />
               )}
             </>
           ) : (

--- a/packages/wuh.site.next/app/post/components/PostComments.tsx
+++ b/packages/wuh.site.next/app/post/components/PostComments.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import styled from '@wuh.site/components/styled'
 import Button from '@wuh.site/components/button'
 import { IconGithub, IconTag } from '@wuh.site/components/icons'
+import Image from '@wuh.site/components/image'
 import message from '@wuh.site/components/message'
 
 type Comment = {
@@ -43,7 +44,7 @@ function formatTime(dateStr?: string): string {
   return date.toLocaleDateString('zh-CN', { month: 'short', day: 'numeric', year: 'numeric' })
 }
 
-function getAvatarText(name: string): string {
+function getAvatarInitial(name: string): string {
   return name.trim().charAt(0).toUpperCase() || '?'
 }
 
@@ -107,6 +108,13 @@ const CommentAvatar = styled.div`
   }
 `
 
+const AvatarFallback = styled.span`
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+`
+
 const CommentBody = styled.div`
   flex: 1;
   min-width: 0;
@@ -146,6 +154,15 @@ const CommentText = styled.div`
   color: var(--text-secondary);
   line-height: 1.6;
   word-break: break-word;
+
+  img {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    border-radius: 8px;
+    border: 1px solid rgba(0, 0, 0, 0.06);
+    background: var(--background-100);
+  }
 `
 
 const CommentStatusBadge = styled.span<{ $status: string }>`
@@ -347,9 +364,16 @@ export default function PostComments({ issueNumber }: Props) {
           <CommentItem key={comment._id || comment.externalId} $isGithub={isGithubComment(comment)}>
             <CommentAvatar>
               {getAvatarUrl(comment) ? (
-                <img src={getAvatarUrl(comment)!} alt={getDisplayName(comment)} />
+                <Image
+                  role='avatar'
+                  src={getAvatarUrl(comment)!}
+                  alt={getDisplayName(comment)}
+                  width={36}
+                  height={36}
+                  errorFallback={<AvatarFallback>{getAvatarInitial(getDisplayName(comment))}</AvatarFallback>}
+                />
               ) : (
-                getAvatarText(getDisplayName(comment))
+                getAvatarInitial(getDisplayName(comment))
               )}
             </CommentAvatar>
             <CommentBody>

--- a/packages/wuh.site.next/app/post/components/PostCover.tsx
+++ b/packages/wuh.site.next/app/post/components/PostCover.tsx
@@ -13,7 +13,7 @@ export default function PostCover({ src, alt }: Props) {
 
   return (
     <CoverImage>
-      <Image src={src} alt={alt} fill ratio='16:9' priority />
+      <Image role='cover' borderRadius='var(--post-cover-radius)' src={src} alt={alt} fill ratio='16:9' priority />
     </CoverImage>
   )
 }

--- a/packages/wuh.site.next/app/post/components/PostHeader.tsx
+++ b/packages/wuh.site.next/app/post/components/PostHeader.tsx
@@ -3,7 +3,8 @@
 import { DiamondDivider } from '@wuh.site/components/icons'
 import type { Issue } from '../PostView.types'
 import { formatFullDate } from '@/app/lib/date'
-import { AuthorRow, AuthorAvatar, AuthorInfo, Header, Title, Summary, OrnamentDivider } from '../styles'
+import Image from '@wuh.site/components/image'
+import { AuthorRow, AuthorAvatarFrame, AuthorInfo, Header, Title, Summary, OrnamentDivider } from '../styles'
 
 type Props = {
   issue: Issue
@@ -23,7 +24,9 @@ export default function PostHeader({ issue }: Props) {
         {/* 作者行 */}
         {avatarUrl && (
           <AuthorRow>
-            <AuthorAvatar src={avatarUrl} alt={userName} width={36} height={36} />
+            <AuthorAvatarFrame>
+              <Image role='avatar' src={avatarUrl} alt={userName} width={32} height={32} />
+            </AuthorAvatarFrame>
             <AuthorInfo>
               <strong>{userName}</strong>
               <span>{date} · {issue.viewCount ?? 0} 次阅读</span>

--- a/packages/wuh.site.next/app/post/styles/post-header.ts
+++ b/packages/wuh.site.next/app/post/styles/post-header.ts
@@ -36,10 +36,11 @@ export const TagGroup = styled.div`
 `
 
 export const CoverImage = styled.div`
+  --post-cover-radius: 12px;
   width: 100%;
   aspect-ratio: 16 / 9;
   max-height: 360px;
-  border-radius: 12px;
+  border-radius: var(--post-cover-radius);
   overflow: hidden;
   margin-bottom: var(--space-lg);
   order: 2;
@@ -52,12 +53,13 @@ export const CoverImage = styled.div`
   }
 
   @media (max-width: 767px) {
+    --post-cover-radius: 0;
     width: calc(100% + 48px);
     height: clamp(220px, 60vw, 300px);
     aspect-ratio: auto;
     max-height: none;
     margin: 0 -24px var(--space-lg);
-    border-radius: 0;
+    border-radius: var(--post-cover-radius);
     order: 1;
   }
 
@@ -87,12 +89,16 @@ export const AuthorRow = styled.div`
   margin-bottom: var(--space-md);
 `
 
-export const AuthorAvatar = styled.img`
+export const AuthorAvatarFrame = styled.span`
+  display: inline-flex;
   width: 36px;
   height: 36px;
+  padding: 2px;
   border-radius: 50%;
   border: 2px solid color-mix(in oklab, var(--accent-color) 30%, transparent);
   flex-shrink: 0;
+
+  > * { width: 100%; height: 100%; }
 `
 
 export const AuthorInfo = styled.div`

--- a/packages/wuh.site.next/app/styles/index.ts
+++ b/packages/wuh.site.next/app/styles/index.ts
@@ -32,9 +32,7 @@ export const Hero = styled.header`
 `
 
 export const StyledLogo = styled(Image).attrs({
-  showSkeleton: false,
   inline: true,
-  appearance: 'plain',
   imageClassName: 'logo-img'
 })`
   width: fit-content;
@@ -293,14 +291,9 @@ export const BookRow = styled.div`
   border-radius: 6px;
 `
 
-export const BookCover = styled(Image).attrs({
-  showSkeleton: true,
-  appearance: 'plain',
-  variant: 'contain',
-})`
+export const BookCover = styled(Image)`
   width: 36px;
   height: 54px;
-  border-radius: 4px;
   flex-shrink: 0;
   box-shadow: 0 1px 3px rgba(0,0,0,0.12);
 `

--- a/packages/wuh.site.next/app/weread/WereadView.tsx
+++ b/packages/wuh.site.next/app/weread/WereadView.tsx
@@ -49,14 +49,9 @@ const BookRow = styled.div`
   border-radius: 6px;
 `
 
-const BookCover = styled(Image).attrs({
-  showSkeleton: true,
-  appearance: 'plain',
-  variant: 'contain',
-})`
+const BookCover = styled(Image)`
   width: 40px;
   height: 54px;
-  border-radius: 4px;
   flex-shrink: 0;
   box-shadow: 0 2px 6px rgba(0,0,0,0.1);
 `
@@ -107,7 +102,7 @@ export default function WereadView({ books, total, currentPage, totalPages }: Pr
           <BookList>
             {books.map((book) => (
               <BookRow key={book.bookId}>
-                <BookCover src={book.cover || ''} alt={book.title} width={40} height={54} />
+                <BookCover role='book-cover' src={book.cover || ''} alt={book.title} width={40} height={54} />
                 <BookInfo>
                   <BookTitle>{book.title}</BookTitle>
                   <BookMeta>{book.author}{book.finishReading ? ' · 已读完' : ' · 阅读中'}</BookMeta>

--- a/packages/wuh.site.next/test/image-role-migration.test.mjs
+++ b/packages/wuh.site.next/test/image-role-migration.test.mjs
@@ -1,0 +1,89 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const testDir = dirname(fileURLToPath(import.meta.url))
+const appRoot = resolve(testDir, '..')
+const root = resolve(appRoot, '..')
+
+const [about, home, homeStyles, weread, postHeader, postHeaderStyles, comments, contact, postCover, footprintStyles, footprintPage, markdownStyles] = await Promise.all([
+  readFile(resolve(appRoot, 'app/about/AboutView.tsx'), 'utf8'),
+  readFile(resolve(appRoot, 'app/HomeView.tsx'), 'utf8'),
+  readFile(resolve(appRoot, 'app/styles/index.ts'), 'utf8'),
+  readFile(resolve(appRoot, 'app/weread/WereadView.tsx'), 'utf8'),
+  readFile(resolve(appRoot, 'app/post/components/PostHeader.tsx'), 'utf8'),
+  readFile(resolve(appRoot, 'app/post/styles/post-header.ts'), 'utf8'),
+  readFile(resolve(appRoot, 'app/post/components/PostComments.tsx'), 'utf8'),
+  readFile(resolve(appRoot, 'app/components/ContactCard.tsx'), 'utf8'),
+  readFile(resolve(appRoot, 'app/post/components/PostCover.tsx'), 'utf8'),
+  readFile(resolve(root, 'components/footprint-map/styles.ts'), 'utf8'),
+  readFile(resolve(appRoot, 'app/footprint/page.tsx'), 'utf8'),
+  readFile(resolve(appRoot, 'app/post/styles/post-markdown.ts'), 'utf8'),
+])
+
+test('About 头像使用 avatar role 且不再以内联圆角修补内部图片', () => {
+  assert.match(about, /role='avatar'/)
+  assert.doesNotMatch(about, /style=\{\{ borderRadius: '50%'/)
+})
+
+test('首页和微信读书页书封使用 book-cover role', () => {
+  assert.match(home, /<S\.BookCover[\s\S]*role='book-cover'/)
+  assert.match(weread, /<BookCover[\s\S]*role='book-cover'/)
+  assert.doesNotMatch(homeStyles, /const BookCover[\s\S]*border-radius:\s*4px/)
+  assert.doesNotMatch(weread, /const BookCover[\s\S]*border-radius:\s*4px/)
+})
+
+test('文章作者头像迁移到共享 avatar role 并保留 accent ring', () => {
+  assert.match(postHeader, /<AuthorAvatar[\s\S]*role='avatar'/)
+  assert.match(postHeaderStyles, /AuthorAvatarFrame/)
+  assert.match(postHeaderStyles, /border:\s*2px solid/)
+})
+
+test('评论头像图片使用 avatar role 并保留首字母 fallback', () => {
+  assert.match(comments, /role='avatar'/)
+  assert.match(comments, /getAvatarInitial/)
+})
+
+test('评论头像错误首字母使用绝对居中容器', () => {
+  assert.match(comments, /const AvatarFallback = styled\.span/)
+  assert.match(comments, /position:\s*absolute/)
+  assert.match(comments, /inset:\s*0/)
+  assert.match(comments, /place-items:\s*center/)
+  assert.match(comments, /errorFallback=\{<AvatarFallback>/)
+})
+
+test('首页和 ContactCard Logo 使用 logo role 与内部图片样式通道', () => {
+  assert.match(home, /<S\.StyledLogo[\s\S]*role='logo'/)
+  assert.match(homeStyles, /imageClassName: 'logo-img'/)
+  assert.match(contact, /role='logo'/)
+  assert.match(contact, /imageClassName='contact-logo'/)
+})
+
+test('ContactCard 二维码使用 qr role 和 contain 语义', () => {
+  assert.match(contact, /role='qr'/)
+  assert.doesNotMatch(contact, /const QRImage = styled\.img/)
+})
+
+test('文章封面使用 cover role 并显式响应移动端圆角', () => {
+  assert.match(postCover, /role='cover'/)
+  assert.match(postCover, /borderRadius='var\(--post-cover-radius\)'/)
+  assert.match(postHeaderStyles, /--post-cover-radius:\s*12px/)
+  assert.match(postHeaderStyles, /--post-cover-radius:\s*0/)
+})
+
+test('足迹照片使用 thumbnail role 并保留预览点击', () => {
+  assert.match(footprintStyles, /styled\(Image\)/)
+  assert.match(footprintPage, /<Photo[\s\S]*role='thumbnail'/)
+  assert.match(footprintPage, /onClick=\{\(\) => handlePhotoClick\(i\)\}/)
+})
+
+test('Markdown 评论和足迹 HTML 图片遵循 content 视觉规范', () => {
+  for (const source of [markdownStyles, comments, footprintStyles]) {
+    assert.match(source, /img\s*\{[\s\S]*max-width:\s*100%/)
+    assert.match(source, /img\s*\{[\s\S]*height:\s*auto/)
+    assert.match(source, /img\s*\{[\s\S]*border-radius:\s*8px/)
+    assert.match(source, /img\s*\{[\s\S]*background:\s*var\(--background-100\)/)
+  }
+})


### PR DESCRIPTION
## 变更摘要

- 为共享 Image 增加 avatar、book-cover、content、cover、thumbnail、logo、qr 语义角色
- 统一 Wrapper、Skeleton 和 fallback 的圆角、背景、边框与裁切职责
- 微信读书书封改为 2px 圆角；头像和 Logo 使用透明失败态
- 迁移 About、文章作者/评论头像、首页/ContactCard Logo、二维码、文章封面和足迹缩略图
- 统一 Markdown、评论和足迹 HTML 图片视觉
- 补充内部图片 imageClassName/imageStyle 通道与兼容迁移提示
- 归档 OpenSpec 并同步 components 主规范与索引

## 验证

已通过：
- `node --test packages/components/test/image-role-contract.test.mjs packages/wuh.site.next/test/image-role-migration.test.mjs`：17/17
- Oxlint：零错误、零警告
- `git diff --check`

环境阻塞，未通过：
- `pnpm -C packages/wuh.site.next exec tsc --noEmit --pretty false`：进程被 SIGSEGV 杀死
- `pnpm -C packages/wuh.site.next exec next build`：Next build worker 被 SIGSEGV 杀死

已对 SIGSEGV 做系统化复现与 trace，表现为当前 macOS x64 Node/TypeScript/Next 工具进程崩溃，而非普通 TypeScript 诊断。浏览器 preview 未完成，因为 3000 端口被现有 Next 进程占用且未接管该进程。

Closes #266