### PR TITLE
docs: migrate docs/superpowers plans to OpenSpec and archive

### DIFF
--- a/openspec/INDEX.md
+++ b/openspec/INDEX.md
@@ -24,8 +24,8 @@
 - **路径:** `openspec/specs/weread-shelf-order/spec.md`
 
 ## seo — SEO 优化
-- **关键词:** SEO, Open Graph, Twitter Card, metadata, Markdown AST, JSON-LD, ProfilePage, canonical, 结构化数据, URL slug
-- **需求:** 全站 Open Graph 标签, Twitter Card 标签, 文章差异化 description, 全站默认 Open Graph 图片, 文章 Twitter 图片回退, 文章作者关键词与分类 metadata, 语义 Markdown 自动摘要, CMS 摘要优先, JSON-LD BlogPosting, About 作者档案结构化数据, canonical URL, 博客 URL 包含标题 slug, 旧 URL 格式向后兼容
+- **关键词:** SEO, Open Graph, Twitter Card, metadata, Markdown AST, JSON-LD, ProfilePage, canonical, 结构化数据, URL slug, ISR, redirect, sitemap, topic pages, 主题页, archive, 归档页, CollectionPage, ItemList, breadcrumb, 面包屑, structured-data builder
+- **需求:** 全站 Open Graph 标签, Twitter Card 标签, 文章差异化 description, 全站默认 Open Graph 图片, 文章 Twitter 图片回退, 文章作者关键词与分类 metadata, 语义 Markdown 自动摘要, CMS 摘要优先, JSON-LD BlogPosting, About 作者档案结构化数据, canonical URL, 博客 URL 包含标题 slug, 旧 URL 格式向后兼容, 文章页对非规范路径永久重定向, 公开文章页不依赖请求 Cookie 且使用 ISR, Sitemap 分页生成并错误即失败, 调试页不进入 sitemap, 根布局 Metadata 默认值, WebSite与Person JSON-LD, BlogPosting builder, 面包屑 JSON-LD, 主题页 canonical 与 sitemap, 主题URL编解码单一入口, 旧 labels 筛选页 noindex, 归档页 canonical, 集合页 CollectionPage 与 ItemList
 - **路径:** `openspec/specs/seo/spec.md`
 
 
@@ -39,8 +39,8 @@
 - **路径:** `openspec/specs/repos-api/spec.md`
 
 ## admin-console — 后台 Console 与权限
-- **关键词:** 后台, Console, Vite, React, GitHub OAuth, root, reader, 博客管理, 留言板, 评论审核
-- **需求:** 独立后台 Console, GitHub 认证登录, stack-wuh 唯一 Root, 其他用户自动 Read, 服务端写权限保护, 博客管理, 留言板管理, 博客评论管理
+- **关键词:** 后台, Console, Vite, React, GitHub OAuth, root, reader, 博客管理, 留言板, 评论审核, 生产部署, 静态镜像, SPA fallback, 同源 API, /v2, Nginx 代理, staging, 健康检查, 发布, 回滚, Cookie, 环境变量边界
+- **需求:** 独立后台 Console, GitHub 认证登录, stack-wuh 唯一 Root, 其他用户自动 Read, 服务端写权限保护, 博客管理, 留言板管理, 博客评论管理, Console 以独立静态镜像发布, Console 容器 SPA 路由, 外部 Nginx 代理保持原始路径, Console 使用同源 API, 生产 OAuth Callback Console 域名, 环境变量不注入 Secret, CI/CD Console 构建与发布, 首次上线同步发布, 后续纯静态变更独立发布, 静态资源缓存策略
 - **路径:** `openspec/specs/admin-console/spec.md`
 
 ## api-standardization — API 标准化
@@ -59,8 +59,8 @@
 - **路径:** `openspec/specs/blog-display/spec.md`
 
 ## blog-detail — 博客详情页
-- **关键词:** 博客详情, 排版, 暗黑模式, WCAG, 对比度, 代码块, 封面图, 正文首图, 相关文章, 继续阅读, 阅读余韵索引, 响应式, 可访问性
-- **需求:** 正文字号与行高, 标题层级字号, 文字色彩对比度, 代码块可读性, 素雅Dark模式完整性, Detail page shows cover below header metadata, Detail page hides unavailable cover image, Detail page hides failed cover image, 相关文章以阅读余韵索引呈现, 索引项提供阅读判断信息, 索引项可访问且具备克制反馈, 索引在窄屏和减少动态偏好下保持可用
+- **关键词:** 博客详情, 排版, 暗黑模式, WCAG, 对比度, 代码块, 封面图, 正文首图, 相关文章, 继续阅读, 阅读余韵索引, 响应式, 可访问性, 主题页链接, Alert 站内外链接
+- **需求:** 正文字号与行高, 标题层级字号, 文字色彩对比度, 代码块可读性, 素雅Dark模式完整性, Detail page shows cover below header metadata, Detail page hides unavailable cover image, Detail page hides failed cover image, 相关文章以阅读余韵索引呈现, 索引项提供阅读判断信息, 索引项可访问且具备克制反馈, 索引在窄屏和减少动态偏好下保持可用, 相关文章基于标签与时间排序去重且最多三篇, 文章标签链接指向站内主题页, Alert 区分站内外链接的打开行为
 - **路径:** `openspec/specs/blog-detail/spec.md`
 
 ## blog-code-highlighting — 代码高亮
@@ -109,8 +109,8 @@
 - **路径:** `openspec/specs/redesign-error-pages/spec.md`
 
 ## build-config — 构建配置
-- **关键词:** 构建, 环境变量, dotenv, MongoDB, health check, sync, Docker, NEST_API_URL
-- **需求:** dotenv环境变量加载, sync:init使用完整NestJS启动, MongooseModule异步工厂, health检查, sync仅同步open issues, Production server API fallback uses Docker service name
+- **关键词:** 构建, 环境变量, dotenv, MongoDB, health check, sync, Docker, NEST_API_URL, Console, Dockerfile, Docker Compose, deploy-docker.sh, staging, 端口规划
+- **需求:** dotenv环境变量加载, sync:init使用完整NestJS启动, MongooseModule异步工厂, health检查, sync仅同步open issues, Production server API fallback uses Docker service name, Dockerfile 支持 Console 构建, Docker Compose 包含 Console 服务, 部署脚本管理 Console 生命周期
 - **路径:** `openspec/specs/build-config/spec.md`
 
 ## code-split — 代码拆分

--- a/openspec/changes/archive/2026-07-26-P-console-production-deployment/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-26-P-console-production-deployment/.openspec.yaml
@@ -1,0 +1,6 @@
+project: x.wuh.site
+change: console-production-deployment
+date: 2026-07-26
+type: P
+status: proposed
+issue: https://github.com/stack-wuh/x.wuh.site/issues/227

--- a/openspec/changes/archive/2026-07-26-P-console-production-deployment/design.md
+++ b/openspec/changes/archive/2026-07-26-P-console-production-deployment/design.md
@@ -1,0 +1,57 @@
+# Console 生产部署设计
+
+## 架构
+
+```text
+浏览器
+  │
+  │ HTTPS
+  ▼
+Nginx:443 (console.wuh.site)
+  │
+  ├── /       ──► 127.0.0.1:3300 ──► Console 静态资源容器
+  │
+  └── /v2/*   ──► 127.0.0.1:3200 ──► NestJS API 容器
+```
+
+Docker Compose 服务规划：
+
+| 服务 | 容器端口 | 主机绑定 | 说明 |
+|---|---:|---:|---|
+| `next` | 3000 | `127.0.0.1:3000` | 现有主站 |
+| `nest` | 3200 | `127.0.0.1:3200` | 认证与 API |
+| `console` | 80 | `127.0.0.1:3300` | Vite 构建后的静态资源 |
+
+NestJS 和 Console 不直接暴露公网，公网入口统一由 Nginx 提供。主站现有 Nginx 配置保持不变，仅新增 `console.wuh.site` 的 server block。
+
+## 技术选型
+
+| 维度 | 选择 | 理由 |
+|------|------|------|
+| Console 静态容器 | Nginx Alpine + Vite dist | 无需 Node.js 进程，复用仓库现有 Nginx 部署经验 |
+| API 前端地址 | `VITE_API_BASE_URL=/v2`（构建时注入） | 同源避免跨域；Vite 环境变量构建时固定，不依赖容器运行时 |
+| OAuth 流程 | NestJS GitHub OAuth + HttpOnly Cookie | 与已归档 admin-console 相同的认证链路 |
+| 容器编排 | Docker Compose（新增 console service） | 复用现有 Next/Nest 的 Compose 文件 |
+| CI/CD | GitHub Actions + `deploy-docker.sh` 扩展 | 不引入第二套发布系统 |
+| staging 端口 | console:3301 / nest:3201 / next:3001 | 三套 staging 保持隔离，正式域名仅在 cutover 后指向生产容器 |
+
+## 复用分析
+
+| 复用项 | 当前状态 | 说明 |
+|-------|--------|------|
+| `scripts/deploy-docker.sh` | 扩展 | 增加 build-console、staging health、switch、diagnose、cancel |
+| `Dockerfile` | 扩展 | 增加 deps、builder-console、runner-console 阶段 |
+| `docker-compose.yml` | 扩展 | 增加 console 生产与 staging 服务定义 |
+| `.github/workflows/` | 扩展 | quality gate 增加 `build:console`，发布依赖增加 console 镜像 |
+| NestJS 认证模块 | 复用 | OAuth callback、Cookie、CORS 均为已有能力，仅增加生产配置 |
+| Nginx 外部代理 | 新建 server block | 仅新增 `console.wuh.site`，不变更主站 Nginx 配置 |
+
+## 影响分析
+
+- **新增依赖:** 无新 npm 依赖；Console 构建依赖已存在于 workspace。
+- **破坏性变更:** 无；主站 Next/Nest 公开行为不变，Console 作为独立域名上线。
+- **环境变量边界:** Console 前端仅注入 `VITE_API_BASE_URL`；所有 secret 仅注入 NestJS 容器。
+- **首次发布:** Console 与 NestJS 必须同步发布，确保 OAuth/API 契约一致。
+- **后续发布:** 纯静态前端变更可独立发布；API、认证、权限契约变更需与 NestJS 绑定发布。
+- **回滚:** Console 使用独立镜像，可按镜像版本回滚；NestJS 保留上一版本镜像。
+- **性能影响:** 纯静态应用，仅外层 Nginx 增加一个 server block 的代理开销。

--- a/openspec/changes/archive/2026-07-26-P-console-production-deployment/proposal.md
+++ b/openspec/changes/archive/2026-07-26-P-console-production-deployment/proposal.md
@@ -1,0 +1,39 @@
+# Console 项目生产部署
+
+## 背景
+
+独立后台 Console、GitHub OAuth、root/reader 权限与后台 API 已由 `2026-07-19-P-admin-console` 实现并归档，但生产环境尚未定义 Console 的独立静态容器、`console.wuh.site` 入口、同源 `/v2/*` 代理、OAuth/Cookie 环境变量和发布回滚流程。
+
+项目现有 GitHub Actions、Docker Compose 和 `scripts/deploy-docker.sh` 已支持 Next/Nest 镜像构建、staging 健康检查与生产切流。Console 应接入该链路，避免建设第二套部署系统。
+
+本提案由原 `docs/superpowers/specs/2026-07-25-console-deployment-design.md` 迁移而来，并以已归档的 Admin Console 需求作为前置依赖。
+
+## 目标
+
+- 通过 `https://console.wuh.site` 独立访问 Console SPA。
+- 将 Vite 构建产物发布为 Nginx 静态容器，生产绑定 `127.0.0.1:3300`。
+- 外层 Nginx 为 Console 提供 HTTPS、SPA 路由和同源 `/v2/*` Nest API 代理。
+- 配置生产 GitHub OAuth callback、HttpOnly Cookie、Console URL 和允许源。
+- 将 Console 镜像纳入现有 CI/CD、staging、健康检查、切流、诊断与回滚流程。
+- 首次上线时 Console 与 NestJS 同步发布；后续纯静态变更允许独立发布。
+- 明确 DNS、证书、服务器环境变量与首次上线验收清单。
+
+## 非目标（明确不做）
+
+- 不迁移到 Vercel、Cloudflare Pages 等托管平台。
+- 不将 Console 合并进主站 `/admin` 路由。
+- 不重新实现 Console 业务、OAuth、root/reader 权限或后台 API。
+- 不在首次上线引入完整蓝绿零停机发布。
+- 不向 Console 前端注入 OAuth secret、JWT secret、MongoDB URI 或 GitHub token。
+- 不改变公开主站域名与现有 Next/Nest 对外行为。
+
+## 影响范围
+
+- `Dockerfile` — 新增 Console deps、builder 和 Nginx runner target。
+- `docker-compose*.yml` — 新增 Console 生产/预发布服务与 3300/3301 端口。
+- `packages/wuh.site.console/` — 生产 API base、构建脚本和容器内 SPA fallback 配置。
+- `.github/workflows/` — 增加 Console quality gate、镜像构建和发布依赖。
+- `scripts/deploy-docker.sh` — 增加 Console build、staging health、switch、diagnose、cancel 和 rollback。
+- 服务器 Nginx/DNS/TLS — 新增 `console.wuh.site` 和 `/v2/*` 原路径代理。
+- `packages/wuh.site.nest/` 环境配置 — OAuth callback、Console URL、Cookie 和 CORS 生产配置。
+- 影响包：`@wuh.site/console`、`@wuh.site/nest`；主站部署配置仅增加健康检查协同。

--- a/openspec/changes/archive/2026-07-26-P-console-production-deployment/specs/admin-console/spec.md
+++ b/openspec/changes/archive/2026-07-26-P-console-production-deployment/specs/admin-console/spec.md
@@ -1,0 +1,116 @@
+---
+artifact: spec
+contractVersion: 1
+requiredHeadings:
+  - ADDED
+requiredPatterns:
+  - '^# Spec: .+'
+  - '^### Requirement: .+'
+  - '^#### Scenario: .+'
+---
+
+# Spec: 后台 Console 生产部署
+
+## ADDED
+
+### Requirement: Console 以独立静态镜像发布
+Console 生产环境 SHALL 以 Nginx Alpine 容器运行 Vite 构建产物，与 Next.js 主站保持独立部署。
+
+#### Scenario: Console 镜像构建与端口绑定
+- **GIVEN** `packages/wuh.site.console` 的 `pnpm run build:console` 成功生成 `dist/`
+- **WHEN** 构建 runner-console 镜像
+- **THEN** 镜像使用 `nginx:alpine` 基础镜像
+- **AND** `dist/` 内容复制到 `/usr/share/nginx/html`
+- **AND** 生产容器端口绑定在 `127.0.0.1:3300`
+
+### Requirement: Console 容器支持 SPA 路由
+Console 容器内 Nginx SHALL 为前端路由提供 SPA fallback。
+
+#### Scenario: SPA 路由刷新不返回 404
+- **GIVEN** 用户访问 `https://console.wuh.site/content` 等前端路由
+- **WHEN** 浏览器刷新或直接访问该路径
+- **THEN** 容器内 Nginx 通过 `try_files $uri $uri/ /index.html` 回退到 `index.html`
+- **AND** 不返回 Nginx 404 页面
+
+### Requirement: 外部 Nginx 代理保持原始路径
+外层 Nginx SHALL 将 `/v2/` 请求以原始路径转发至 NestJS，不修改请求路径。
+
+#### Scenario: /v2 请求原路径转发
+- **GIVEN** 外部 Nginx 配置 `location /v2/`
+- **WHEN** 请求 `https://console.wuh.site/v2/auth/me` 到达
+- **THEN** 代理至 `http://127.0.0.1:3200/v2/auth/me`，路径保持原样
+- **AND** 不因 `proxy_pass` 配置导致路径被截断或改变
+
+### Requirement: Console 使用同源 API
+Console 前端 SHALL 通过同源路径 `/v2` 访问 NestJS API，避免跨域和 Cookie 配置复杂度。
+
+#### Scenario: 生产环境 API 地址
+- **GIVEN** 生产构建
+- **WHEN** Vite 构建 Console
+- **THEN** `VITE_API_BASE_URL` 为 `/v2`
+- **AND** 不依赖容器运行时环境变量或全局注入
+
+#### Scenario: 本地开发覆盖
+- **GIVEN** 本地开发环境
+- **WHEN** 启动 Console 开发服务器
+- **THEN** 可通过 `.env.local` 覆盖为 `http://localhost:3200/v2`
+
+### Requirement: 生产 OAuth Callback 使用 Console 域名
+生产 GitHub OAuth SHALL 回调至 `https://console.wuh.site/v2/auth/github/callback` 且 Cookie 满足安全属性。
+
+#### Scenario: 生产环境 OAuth 配置
+- **GIVEN** 生产 GitHub OAuth App 配置完成
+- **WHEN** 用户通过 Console 登录
+- **THEN** NestJS 校验 state、交换 GitHub code 并写入用户记录
+- **AND** `access_token` Cookie 为 `HttpOnly=true; Secure=true; SameSite=Lax; Path=/`
+- **AND** 登录后重定向到 `https://console.wuh.site/`
+
+### Requirement: 环境变量不向 Console 前端注入 Secret
+Console 构建阶段注入的环境变量 SHALL 不包含任何 Secret。
+
+#### Scenario: 禁止注入前端的变量
+- **GIVEN** Console 的 `VITE_*` 环境变量在构建时注入
+- **WHEN** 检查构建产物
+- **THEN** 不得包含 `GITHUB_OAUTH_CLIENT_SECRET`、`JWT_SECRET`、`MONGO_URI` 或 `GITHUB_PERSONAL_TOKEN`
+
+### Requirement: CI/CD 中 Console 参与构建与发布
+CI/CD 流水线 SHALL 将 Console 纳入质量门禁、镜像构建、staging 和发布流程。
+
+#### Scenario: quality gate 包含 Console 构建
+- **GIVEN** GitHub Actions 执行 quality gate
+- **WHEN** 运行 `pnpm run build:console`
+- **THEN** 构建失败阻断后续流程
+
+#### Scenario: staging 三服务健康检查
+- **GIVEN** staging 容器启动
+- **WHEN** 执行健康检查
+- **THEN** `curl -f http://127.0.0.1:3301/` 返回成功
+- **AND** `curl -f http://127.0.0.1:3201/v2/health` 返回成功
+- **AND** `curl -f http://127.0.0.1:3001/` 返回成功
+
+### Requirement: 首次上线 Console 与 NestJS 同步发布
+Console 首次上线 SHALL 与 NestJS 同步发布，确保 OAuth、API 和权限契约一致。
+
+#### Scenario: 首次上线发布序列
+- **GIVEN** Console 与 NestJS 变更为首次生产部署
+- **WHEN** 合并到 `main` 并触发发布
+- **THEN** 两个服务在同一发布中构建与切换
+- **AND** 发布含 Console 容器、NestJS 容器与生产 GitHub OAuth App 配置
+
+### Requirement: 后续纯静态变更独立发布
+Console 纯前端静态变更 SHALL 可独立发布，不影响 NestJS。
+
+#### Scenario: 独立发布条件
+- **GIVEN** Console 变更仅涉及样式、布局、文案或前端交互
+- **WHEN** 打包 Console 镜像并部署
+- **THEN** NestJS 不强制同步发布
+- **AND** 不改变 API 请求格式、OAuth 流程或权限逻辑
+
+### Requirement: 静态资源缓存策略
+Console 静态资源 SHALL 按文件类型区分缓存策略。
+
+#### Scenario: HTML 与带 hash 资源分别缓存
+- **GIVEN** Console 的 Nginx 配置
+- **WHEN** 响应请求
+- **THEN** `index.html` 不进行长期缓存
+- **AND** 带 hash 的 JS、CSS 与字体使用长期缓存

--- a/openspec/changes/archive/2026-07-26-P-console-production-deployment/specs/build-config/spec.md
+++ b/openspec/changes/archive/2026-07-26-P-console-production-deployment/specs/build-config/spec.md
@@ -1,0 +1,46 @@
+---
+artifact: spec
+contractVersion: 1
+requiredHeadings:
+  - ADDED
+requiredPatterns:
+  - '^# Spec: .+'
+  - '^### Requirement: .+'
+  - '^#### Scenario: .+'
+---
+
+# Spec: 构建配置
+
+## ADDED
+
+### Requirement: Dockerfile 支持 Console 构建
+Dockerfile SHALL 提供 deps、builder 和 runner 阶段以构建 Console 静态镜像。
+
+#### Scenario: Console 多阶段构建
+- **GIVEN** pnpm workspace 中包含 `packages/wuh.site.console`
+- **WHEN** 执行 Docker 构建
+- **THEN** deps 阶段复制 Console `package.json` 并安装 workspace 依赖
+- **AND** builder-console 阶段执行 `pnpm run build:console`
+- **AND** runner-console 阶段使用 `nginx:alpine` 提供静态文件服务
+
+### Requirement: Docker Compose 包含 Console 服务
+Docker Compose 配置 SHALL 定义生产与 staging Console 服务。
+
+#### Scenario: 生产与 staging 端口规划
+- **GIVEN** Compose 文件包含 next、nest、console 服务
+- **WHEN** 启动生产容器
+- **THEN** console 绑定 `127.0.0.1:3300`
+- **WHEN** 启动 staging 容器
+- **THEN** console staging 绑定 `127.0.0.1:3301`、nest staging 绑定 `127.0.0.1:3201`、next staging 绑定 `127.0.0.1:3001`
+
+### Requirement: 部署脚本管理 Console 生命周期
+`deploy-docker.sh` SHALL 为 Console 提供 build、staging health、switch、diagnose、cancel 和 rollback 能力。
+
+#### Scenario: deploy-docker.sh Console 命令
+- **GIVEN** 部署脚本已扩展 Console 支持
+- **WHEN** 执行 `build-console`
+- **THEN** 构建 Console 镜像
+- **WHEN** 执行 `diagnose`
+- **THEN** 包含 Console 容器状态检查
+- **WHEN** 执行 `cancel`
+- **THEN** 清理 staging Console 容器

--- a/openspec/changes/archive/2026-07-26-P-console-production-deployment/tasks.md
+++ b/openspec/changes/archive/2026-07-26-P-console-production-deployment/tasks.md
@@ -1,0 +1,60 @@
+# Console 生产部署任务
+
+> 任务基于 `docs/superpowers/specs/2026-07-25-console-deployment-design.md` 提取，优先级由首次上线顺序与可独立验证程度决定。
+
+## Phase 1：CI 与镜像准备
+
+- [ ] 在 `Dockerfile` 中增加 Console deps、builder 与 runner-console 阶段。
+  文件：`Dockerfile`  
+  预计耗时：1.5 小时；实际耗时：待记录
+- [ ] 在 `docker-compose.yml` 与 `docker-compose.staging.yml` 中增加 console 服务（3300/3301）。
+  文件：`docker-compose.yml`、`docker-compose.staging.yml`  
+  预计耗时：1 小时；实际耗时：待记录
+- [ ] 在 `.github/workflows/` 增加 Console quality gate（`pnpm run build:console`）与镜像构建/推送步骤。
+  文件：`.github/workflows/deploy.yml`  
+  预计耗时：1 小时；实际耗时：待记录
+
+## Phase 2：部署脚本
+
+- [ ] 在 `scripts/deploy-docker.sh` 增加 `build-console` 命令。
+- [ ] 在 staging 阶段增加 `127.0.0.1:3301` 健康检查。
+- [ ] 在 `diagnose` 中检查 Console 容器状态。
+- [ ] 在 `cancel` 中清理 staging Console 容器。
+- [ ] 在 `switch-traffic` 中启动生产 Console 容器。
+  文件：`scripts/deploy-docker.sh`  
+  预计耗时：2 小时；实际耗时：待记录
+
+## Phase 3：Console 容器内配置
+
+- [ ] 容器内 Nginx 配置 SPA fallback（`try_files $uri $uri/ /index.html`）。
+- [ ] `index.html` 不长期缓存；带 hash 的 JS/CSS/字体使用长期缓存。
+- [ ] 生产 `VITE_API_BASE_URL=/v2` 构建时注入；本地开发通过 `.env.local` 覆盖为 `http://localhost:3200/v2`。
+  文件：`packages/wuh.site.console/`、Console Dockerfile  
+  预计耗时：1 小时；实际耗时：待记录
+
+## Phase 4：外部 Nginx、DNS 与 TLS
+
+- [ ] 配置 `console.wuh.site` DNS A 记录。
+- [ ] 新增 Nginx server block：HTTP → HTTPS 重定向、TLS 终止、`/` → `127.0.0.1:3300`、`/v2/` → `127.0.0.1:3200`。
+- [ ] 传递 `Host`、`X-Real-IP`、`X-Forwarded-For`、`X-Forwarded-Proto`。
+- [ ] `/v2/` 使用不带路径追加的 `proxy_pass`，保留原始请求路径。
+  文件：服务器 Nginx 配置、DNS 记录、TLS 证书  
+  预计耗时：1.5 小时；实际耗时：待记录
+
+## Phase 5：生产环境变量与 OAuth
+
+- [ ] 配置生产 GitHub OAuth App（Homepage URL、callback URL 指向 `console.wuh.site`）。
+- [ ] 配置 NestJS 生产环境变量（`GITHUB_OAUTH_*`、`CONSOLE_URL`、`JWT_SECRET`、`CORS_ORIGIN` 包含 console.wuh.site）。
+- [ ] 确认 Console 前端仅注入 `VITE_API_BASE_URL`，无 secret 泄漏。
+  文件：`.env`（服务器端）、GitHub OAuth App 设置  
+  预计耗时：1 小时；实际耗时：待记录
+
+## Phase 6：首次上线与验收
+
+- [ ] 合并 Console 与 NestJS 变更到 `main`。
+- [ ] 构建 Next、Nest、Console 三个镜像并推送。
+- [ ] 在服务器上启动 staging 三服务并通过健康检查。
+- [ ] 切换生产流量。
+- [ ] 验证 `console.wuh.site/` 返回登录页，SPA 路由刷新不 404，无 mixed content。
+- [ ] 验证 OAuth 登录、HttpOnly Secure Cookie、`/v2/auth/me`、root/reader 权限与登出。
+  预计耗时：2 小时；实际耗时：待记录

--- a/openspec/changes/archive/2026-07-26-P-seo-discovery-navigation/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-26-P-seo-discovery-navigation/.openspec.yaml
@@ -1,0 +1,5 @@
+project: x.wuh.site
+change: seo-discovery-navigation
+date: 2026-07-26
+type: P
+status: proposed

--- a/openspec/changes/archive/2026-07-26-P-seo-discovery-navigation/design.md
+++ b/openspec/changes/archive/2026-07-26-P-seo-discovery-navigation/design.md
@@ -1,0 +1,58 @@
+# SEO 内容发现与站内导航设计
+
+## 架构
+
+SEO 能力按“规范 URL → 可抓取入口 → 聚合页 → 结构化数据”组织：
+
+```text
+Content API
+├─ 分页文章 ──► canonical post URLs ──► sitemap / archive
+├─ 标签汇总 ──► canonical topic URLs ──► sitemap / topic pages
+└─ 标签候选 ──► related-post selector ──► post detail links
+
+Next.js server pages
+├─ Metadata API：canonical、robots、title、description
+├─ JSON-LD builders：WebSite、Person、BlogPosting、BreadcrumbList、CollectionPage、ItemList
+└─ ISR：公开内容按小时重验证，不依赖用户 Cookie
+```
+
+文章编号继续作为内容查询键，标题 slug 只承担规范 URL 和可读性。非规范路径永久重定向至当前标题生成的 canonical URL。主题参数通过单一 URL 工具编码和解码，避免页面、sitemap 与链接生成规则分叉。
+
+## 技术选型
+
+- 使用 Next.js App Router Metadata API 输出 canonical、robots 和页面 metadata。
+- 使用纯 TypeScript builder 生成 Schema.org JSON-LD，页面仅负责提供数据和渲染。
+- 使用现有 Content API 的分页、单标签查询与标签汇总能力，不新增接口。
+- 使用服务端组件获取公开内容并配置 `revalidate: 3600`。
+- 相关文章使用纯函数完成排除当前文章、按编号去重、共享标签数与更新时间排序，最多返回三篇。
+
+## 复用分析
+
+- 复用 `buildPostUrl` 生成文章 canonical URL。
+- 复用 Content API 的 `getPosts.server` 与 `getLabels.server`。
+- 复用现有 `JsonLd` 渲染组件。
+- 复用博客列表样式与文章详情 `PostView`，不建立新的通用组件包抽象。
+- 已归档的“阅读余韵索引”继续作为相关文章表现层规范，本变更不覆盖其视觉契约。
+
+## 影响分析
+
+- `app/post/[number]/page.tsx` 不再依赖请求 Cookie，可由 ISR 缓存；非 canonical 路径会永久重定向。
+- sitemap 必须分页读取全部 open 文章；任一页加载失败时显式失败，避免生成不完整索引。
+- `/blog?labels=` 保留兼容但设为 noindex/follow，索引入口迁移至 `/topics/[label]`。
+- 主题页与归档页均输出 canonical metadata 和 CollectionPage/ItemList JSON-LD。
+- Alert 仅对外部链接设置新窗口与安全属性，站内主题链接保持同窗口导航。
+- 不涉及数据库、DTO 或后端路由变更。
+
+## 数据与接口
+
+- 文章 sitemap 数据使用 `number`、`title`、`updatedAtGitHub`、`createdAtGitHub`。
+- 相关文章候选使用 `number`、`title`、`labels`、`updatedAt` 和可选 `summary`。
+- topic URL 采用 `/topics/<encodeURIComponent(label)>`。
+- archive URL 固定为 `/archive`，内容按文章年份分组。
+- 集合 JSON-LD 的 `ItemList` 条目使用 canonical 文章 URL，并按页面顺序从 1 递增。
+
+## 回滚
+
+- 主题页、归档页与结构化数据均为新增公开入口，可独立移除。
+- canonical 重定向回滚时仍需保留旧数字 URL 的正常渲染能力。
+- sitemap 变更可回退到上一个生成器，但不得输出调试页或 query 筛选 URL。

--- a/openspec/changes/archive/2026-07-26-P-seo-discovery-navigation/proposal.md
+++ b/openspec/changes/archive/2026-07-26-P-seo-discovery-navigation/proposal.md
@@ -1,0 +1,29 @@
+# SEO 内容发现与站内导航
+
+## 背景
+
+`docs/superpowers/plans/` 中保存了 2026-07-23 至 2026-07-25 的 SEO P0、P1 与 P1.2–P1.7 实施计划。这些计划共同定义了文章 URL 规范化、结构化数据、相关文章、主题页、归档页、sitemap 与索引策略，但尚未形成统一的 OpenSpec 规范。
+
+本变更将这些历史计划迁移为可长期维护的需求制品。已单独归档的“阅读余韵索引”视觉设计不重复迁移，仅保留相关文章的数据发现与站内链接契约。
+
+## 目标
+
+- 统一文章 canonical URL、永久重定向、ISR、全局 metadata 与 sitemap 抓取策略。
+- 为站点、作者、文章、面包屑及集合页提供一致的 Schema.org JSON-LD。
+- 提供最多三篇、去重且按相关度排序的相关文章。
+- 建立可索引的 `/topics/[label]` 主题页与 `/archive` 年份归档页。
+- 将主题页和归档页加入 sitemap，并让旧 query 筛选页保持 noindex/follow。
+- 将文章标签与博客标签入口统一指向站内主题页。
+
+## 非目标（明确不做）
+
+- 不重复定义已归档的相关文章视觉表现层。
+- 不新增后端 API；复用现有内容分页、标签查询与标签汇总接口。
+- 不改变 GitHub Issues 作为 CMS 的数据来源。
+- 不引入新的 SEO SaaS、分析平台或第三方依赖。
+
+## 影响范围
+
+- `packages/wuh.site.next/app/` — metadata、文章页、主题页、归档页、sitemap、结构化数据和站内导航。
+- `packages/components/alert/` — 内部链接与外部链接的打开策略。
+- 影响规范：`seo`、`blog-detail`。

--- a/openspec/changes/archive/2026-07-26-P-seo-discovery-navigation/specs/blog-detail/spec.md
+++ b/openspec/changes/archive/2026-07-26-P-seo-discovery-navigation/specs/blog-detail/spec.md
@@ -1,0 +1,35 @@
+---
+artifact: spec
+contractVersion: 1
+requiredHeadings:
+  - ADDED
+requiredPatterns:
+  - '^# Spec: .+'
+  - '^### Requirement: .+'
+  - '^- \*\*GIVEN\*\* .+'
+---
+
+# Spec: 博客详情页
+
+## ADDED
+
+### Requirement: 相关文章基于标签与时间排序、去重且最多三篇
+- **GIVEN** 当前文章最多三个非空标签
+- **WHEN** 获取相关文章候选
+- **THEN** 每个标签并发请求最多 10 篇候选文章
+- **AND** `selectRelatedPosts` 排除当前文章编号并按共享标签数降序、更新时间降序、编号升序排序
+- **AND** 同一编号仅保留第一条，总数不超过 3 篇
+- **AND** 无标签或全部请求失败时返回空数组
+
+### Requirement: 文章标签链接指向站内主题页
+- **GIVEN** 文章详情页渲染标签
+- **WHEN** 生成标签链接
+- **THEN** 使用 `buildTopicUrl(label.name)` 生成 `/topics/<encoded>` 站内链接
+- **AND** 不再构造 GitHub Issue label query URL
+
+### Requirement: Alert 区分站内外链接的打开行为
+- **GIVEN** Alert 组件渲染带链接的内容
+- **WHEN** 链接 href 是外部域名
+- **THEN** 设置 `target="_blank"` 与 `rel="noopener noreferrer"`
+- **WHEN** 链接 href 是站内路径
+- **THEN** 不设置 `target="_blank"`，保持同窗口导航

--- a/openspec/changes/archive/2026-07-26-P-seo-discovery-navigation/specs/seo/spec.md
+++ b/openspec/changes/archive/2026-07-26-P-seo-discovery-navigation/specs/seo/spec.md
@@ -1,85 +1,17 @@
-# SEO
+---
+artifact: spec
+contractVersion: 1
+requiredHeadings:
+  - ADDED
+requiredPatterns:
+  - '^# Spec: .+'
+  - '^### Requirement: .+'
+  - '^- \*\*GIVEN\*\* .+'
+---
+
+# Spec: SEO
 
 ## ADDED
-
-### Requirement: 全站 Open Graph 标签
-- **GIVEN** 任意页面被社交平台抓取
-- **WHEN** 爬虫读取 HTML
-- **THEN** 包含 `og:title`、`og:description`、`og:image`、`og:url`、`og:type` 标签
-
-### Requirement: Twitter Card 标签
-- **GIVEN** 页面链接被分享到 Twitter
-- **WHEN** Twitter 爬虫抓取
-- **THEN** 包含 `twitter:card`、`twitter:title`、`twitter:description`、`twitter:image` 标签
-
-### Requirement: 文章差异化 description
-- **GIVEN** 博客文章有 metadata.summary 或 body
-- **WHEN** 生成页面 metadata
-- **THEN** description 优先使用 summary，fallback 到正文前 160 字
-
-### Requirement: JSON-LD BlogPosting 结构化数据
-- **GIVEN** 博客详情页
-- **WHEN** 搜索引擎爬取
-- **THEN** 包含 `application/ld+json` 的 BlogPosting schema
-
-### Requirement: canonical URL
-- **GIVEN** 博客详情页
-- **WHEN** 搜索引擎索引
-- **THEN** canonical URL 包含标题 slug，格式为 `https://wuh.site/post/<number>-<slug>`
-- **AND** slug 来源于文章标题
-
-### Requirement: 博客 URL 包含标题 slug
-- **GIVEN** 首页或博客列表页展示博客文章列表
-- **WHEN** 用户或搜索引擎抓取链接
-- **THEN** 博客详情页链接格式为 `/post/<number>-<title-slug>`
-- **AND** slug 中保留中文字符，URL 敏感字符（`#`、`?`、`&`、`/`、`\`）替换为 `-`
-- **AND** 连续的 `-` 压缩为单个 `-`
-
-### Requirement: 旧 URL 格式向后兼容
-- **GIVEN** 存在历史链接 `/post/123`（无 slug）
-- **WHEN** 用户访问该链接
-- **THEN** 页面正常渲染，不 404
-
-### Requirement: 全站默认 Open Graph 图片
-- **GIVEN** 任意页面生成 Open Graph metadata，或博客文章没有显式封面
-- **WHEN** Next.js 生成页面 metadata
-- **THEN** `openGraph.images` 至少包含一张可访问的 1200×630 默认图片
-- **AND** 文章存在显式封面时优先使用显式封面
-
-### Requirement: 文章 Twitter 图片回退
-- **GIVEN** 博客文章没有显式封面
-- **WHEN** Next.js 生成 Twitter Card metadata
-- **THEN** `twitter.images` 使用全站默认 1200×630 图片
-- **AND** `twitter.card` 保持适合大图展示的卡片类型
-
-### Requirement: 文章作者关键词与分类 metadata
-- **GIVEN** 博客文章包含作者、CMS keywords、文章标签或可推导的分类信息
-- **WHEN** 生成文章 metadata
-- **THEN** metadata 可表达 `authors`、`keywords` 和 `category`
-- **AND** `keywords` 优先使用 CMS metadata keywords
-- **AND** CMS keywords 缺失时回退到文章标签
-
-### Requirement: 语义 Markdown 自动摘要
-- **GIVEN** 博客文章没有 CMS `summary` 且正文包含 Markdown 内容
-- **WHEN** 生成 description 或 BlogPosting 的 description
-- **THEN** 使用 Markdown AST 提取首个有效段落
-- **AND** 忽略代码块、标题和空白内容
-- **AND** 摘要长度遵守现有 metadata 展示上限并保持可读文本
-
-### Requirement: CMS 摘要优先
-- **GIVEN** 博客文章存在非空 CMS `summary`
-- **WHEN** 生成 description 或 BlogPosting 的 description
-- **THEN** 直接使用 CMS `summary`
-- **AND** 不使用自动 Markdown 摘要覆盖 CMS 内容
-
-### Requirement: About 作者档案结构化数据
-- **GIVEN** 用户或搜索引擎访问 `/about`
-- **WHEN** 页面输出 JSON-LD
-- **THEN** 包含 `ProfilePage` 类型的结构化数据
-- **AND** `ProfilePage` 的 mainEntity 对应站点 Person 实体
-- **AND** Person 实体与 `https://github.com/stack-wuh` 建立 `sameAs` 或等价对应关系
-
-## ADDED (2026-07-26)
 
 ### Requirement: 文章页对非规范路径永久重定向
 - **GIVEN** 文章通过 `/post/<number>` 或其历史 slug 被访问

--- a/openspec/changes/archive/2026-07-26-P-seo-discovery-navigation/tasks.md
+++ b/openspec/changes/archive/2026-07-26-P-seo-discovery-navigation/tasks.md
@@ -1,0 +1,54 @@
+# SEO 内容发现与站内导航任务
+
+> 本文件由历史实施计划迁移而来，仅记录制品对应的实施边界；代码已在原计划对应变更中完成，归档前以现有实现和测试结果为准。
+
+## Phase 1：URL、metadata 与 sitemap 基础
+
+- [x] 规范化文章 URL 并对非 canonical 路径永久重定向。  
+  文件：`packages/wuh.site.next/app/lib/slug.ts`、`packages/wuh.site.next/app/post/[number]/page.tsx`  
+  预计耗时：1 小时；实际耗时：历史实施，未记录
+- [x] 为公开文章启用 ISR，移除 SEO 渲染的 Cookie 依赖。  
+  文件：`packages/wuh.site.next/app/post/[number]/page.tsx`  
+  预计耗时：30 分钟；实际耗时：历史实施，未记录
+- [x] 分页生成 canonical sitemap，排除调试页并为调试页设置 noindex。  
+  文件：`packages/wuh.site.next/app/sitemap.ts`、`packages/wuh.site.next/app/design/system-color/layout.tsx`  
+  预计耗时：1 小时；实际耗时：历史实施，未记录
+- [x] 补齐全局 metadata 默认值。  
+  文件：`packages/wuh.site.next/app/layout.tsx`  
+  预计耗时：30 分钟；实际耗时：历史实施，未记录
+
+## Phase 2：结构化数据
+
+- [x] 建立 WebSite、Person、BlogPosting 与 BreadcrumbList builder。  
+  文件：`packages/wuh.site.next/app/lib/structured-data.ts`、`packages/wuh.site.next/app/layout.tsx`、`packages/wuh.site.next/app/post/[number]/page.tsx`  
+  预计耗时：2 小时；实际耗时：历史实施，未记录
+- [x] 在文章页渲染可访问面包屑。  
+  文件：`packages/wuh.site.next/app/post/PostView.tsx`、`packages/wuh.site.next/app/post/styles/`  
+  预计耗时：1 小时；实际耗时：历史实施，未记录
+- [x] 为主题页和归档页输出 CollectionPage 与 ItemList。  
+  文件：`packages/wuh.site.next/app/lib/structured-data.ts`、`packages/wuh.site.next/app/topics/[label]/page.tsx`、`packages/wuh.site.next/app/archive/page.tsx`  
+  预计耗时：1 小时；实际耗时：历史实施，未记录
+
+## Phase 3：内容发现与站内链接
+
+- [x] 选择、去重和排序最多三篇相关文章。  
+  文件：`packages/wuh.site.next/app/lib/related-posts.ts`、`packages/wuh.site.next/app/post/[number]/page.tsx`  
+  预计耗时：1 小时；实际耗时：历史实施，未记录
+- [x] 建立可索引主题页并统一标签链接。  
+  文件：`packages/wuh.site.next/app/lib/topic-url.ts`、`packages/wuh.site.next/app/topics/[label]/page.tsx`、`packages/wuh.site.next/app/blog/BlogListView.tsx`、`packages/wuh.site.next/app/post/PostView.tsx`  
+  预计耗时：2 小时；实际耗时：历史实施，未记录
+- [x] 将主题页加入 sitemap，并将旧标签 query 页设为 noindex/follow。  
+  文件：`packages/wuh.site.next/app/lib/sitemap.ts`、`packages/wuh.site.next/app/sitemap.ts`、`packages/wuh.site.next/app/blog/page.tsx`  
+  预计耗时：1 小时；实际耗时：历史实施，未记录
+- [x] 建立年份归档页、sitemap 条目和博客入口。  
+  文件：`packages/wuh.site.next/app/archive/page.tsx`、`packages/wuh.site.next/app/lib/sitemap.ts`、`packages/wuh.site.next/app/blog/BlogListView.tsx`  
+  预计耗时：2 小时；实际耗时：历史实施，未记录
+- [x] 区分 Alert 站内与站外链接行为。  
+  文件：`packages/components/alert/index.tsx`  
+  预计耗时：30 分钟；实际耗时：历史实施，未记录
+
+## Phase 4：验证
+
+- [x] 运行对应 SEO Node 测试、前端 lint、TypeScript 与 diff 检查。  
+  文件：`packages/wuh.site.next/test/seo-*.test.mjs`、`packages/wuh.site.next/test/topic-url.test.mjs`、`packages/wuh.site.next/test/related-posts.test.mjs`  
+  预计耗时：1 小时；实际耗时：历史实施，详见原提交记录

--- a/openspec/specs/admin-console/spec.md
+++ b/openspec/specs/admin-console/spec.md
@@ -102,3 +102,105 @@ Console 前端 SHALL 根据当前用户角色展示可用操作，但所有权�
 - **WHEN** API 返回列表、错误或 Swagger 文档
 - **THEN** 列表应复用统一分页响应格式，错误应复用统一异常格式，接口应可被 Swagger 文档发现
 - **AND** 新增接口不应破坏现有公开内容 API 与主站展示行为
+
+### Requirement: Console 以独立静态镜像发布
+Console 生产环境 SHALL 以 Nginx Alpine 容器运行 Vite 构建产物，与 Next.js 主站保持独立部署。
+
+#### Scenario: Console 镜像构建与端口绑定
+- **GIVEN** `packages/wuh.site.console` 的 `pnpm run build:console` 成功生成 `dist/`
+- **WHEN** 构建 runner-console 镜像
+- **THEN** 镜像使用 `nginx:alpine` 基础镜像
+- **AND** `dist/` 内容复制到 `/usr/share/nginx/html`
+- **AND** 生产容器端口绑定在 `127.0.0.1:3300`
+
+### Requirement: Console 容器支持 SPA 路由
+Console 容器内 Nginx SHALL 为前端路由提供 SPA fallback。
+
+#### Scenario: SPA 路由刷新不返回 404
+- **GIVEN** 用户访问 `https://console.wuh.site/content` 等前端路由
+- **WHEN** 浏览器刷新或直接访问该路径
+- **THEN** 容器内 Nginx 通过 `try_files $uri $uri/ /index.html` 回退到 `index.html`
+- **AND** 不返回 Nginx 404 页面
+
+### Requirement: 外部 Nginx 代理保持原始路径
+外层 Nginx SHALL 将 `/v2/` 请求以原始路径转发至 NestJS，不修改请求路径。
+
+#### Scenario: /v2 请求原路径转发
+- **GIVEN** 外部 Nginx 配置 `location /v2/`
+- **WHEN** 请求 `https://console.wuh.site/v2/auth/me` 到达
+- **THEN** 代理至 `http://127.0.0.1:3200/v2/auth/me`，路径保持原样
+- **AND** 不因 `proxy_pass` 配置导致路径被截断或改变
+
+### Requirement: Console 使用同源 API
+Console 前端 SHALL 通过同源路径 `/v2` 访问 NestJS API，避免跨域和 Cookie 配置复杂度。
+
+#### Scenario: 生产环境 API 地址
+- **GIVEN** 生产构建
+- **WHEN** Vite 构建 Console
+- **THEN** `VITE_API_BASE_URL` 为 `/v2`
+- **AND** 不依赖容器运行时环境变量或全局注入
+
+#### Scenario: 本地开发覆盖
+- **GIVEN** 本地开发环境
+- **WHEN** 启动 Console 开发服务器
+- **THEN** 可通过 `.env.local` 覆盖为 `http://localhost:3200/v2`
+
+### Requirement: 生产 OAuth Callback 使用 Console 域名
+生产 GitHub OAuth SHALL 回调至 `https://console.wuh.site/v2/auth/github/callback` 且 Cookie 满足安全属性。
+
+#### Scenario: 生产环境 OAuth 配置
+- **GIVEN** 生产 GitHub OAuth App 配置完成
+- **WHEN** 用户通过 Console 登录
+- **THEN** NestJS 校验 state、交换 GitHub code 并写入用户记录
+- **AND** `access_token` Cookie 为 `HttpOnly=true; Secure=true; SameSite=Lax; Path=/`
+- **AND** 登录后重定向到 `https://console.wuh.site/`
+
+### Requirement: 环境变量不向 Console 前端注入 Secret
+Console 构建阶段注入的环境变量 SHALL 不包含任何 Secret。
+
+#### Scenario: 禁止注入前端的变量
+- **GIVEN** Console 的 `VITE_*` 环境变量在构建时注入
+- **WHEN** 检查构建产物
+- **THEN** 不得包含 `GITHUB_OAUTH_CLIENT_SECRET`、`JWT_SECRET`、`MONGO_URI` 或 `GITHUB_PERSONAL_TOKEN`
+
+### Requirement: CI/CD 中 Console 参与构建与发布
+CI/CD 流水线 SHALL 将 Console 纳入质量门禁、镜像构建、staging 和发布流程。
+
+#### Scenario: quality gate 包含 Console 构建
+- **GIVEN** GitHub Actions 执行 quality gate
+- **WHEN** 运行 `pnpm run build:console`
+- **THEN** 构建失败阻断后续流程
+
+#### Scenario: staging 三服务健康检查
+- **GIVEN** staging 容器启动
+- **WHEN** 执行健康检查
+- **THEN** `curl -f http://127.0.0.1:3301/` 返回成功
+- **AND** `curl -f http://127.0.0.1:3201/v2/health` 返回成功
+- **AND** `curl -f http://127.0.0.1:3001/` 返回成功
+
+### Requirement: 首次上线 Console 与 NestJS 同步发布
+Console 首次上线 SHALL 与 NestJS 同步发布，确保 OAuth、API 和权限契约一致。
+
+#### Scenario: 首次上线发布序列
+- **GIVEN** Console 与 NestJS 变更为首次生产部署
+- **WHEN** 合并到 `main` 并触发发布
+- **THEN** 两个服务在同一发布中构建与切换
+- **AND** 发布含 Console 容器、NestJS 容器与生产 GitHub OAuth App 配置
+
+### Requirement: 后续纯静态变更独立发布
+Console 纯前端静态变更 SHALL 可独立发布，不影响 NestJS。
+
+#### Scenario: 独立发布条件
+- **GIVEN** Console 变更仅涉及样式、布局、文案或前端交互
+- **WHEN** 打包 Console 镜像并部署
+- **THEN** NestJS 不强制同步发布
+- **AND** 不改变 API 请求格式、OAuth 流程或权限逻辑
+
+### Requirement: 静态资源缓存策略
+Console 静态资源 SHALL 按文件类型区分缓存策略。
+
+#### Scenario: HTML 与带 hash 资源分别缓存
+- **GIVEN** Console 的 Nginx 配置
+- **WHEN** 响应请求
+- **THEN** `index.html` 不进行长期缓存
+- **AND** 带 hash 的 JS、CSS 与字体使用长期缓存

--- a/openspec/specs/blog-detail/spec.md
+++ b/openspec/specs/blog-detail/spec.md
@@ -101,3 +101,24 @@ AND 不应显示破图、错误提示或占位图
 - **THEN** 文字不应造成横向滚动且单项触达高度不低于 44px
 - **AND** 摘要最多显示两行，标签可自然换行
 - **AND** 在 prefers-reduced-motion 下不得执行箭头位移动画
+
+### Requirement: 相关文章基于标签与时间排序、去重且最多三篇
+- **GIVEN** 当前文章最多三个非空标签
+- **WHEN** 获取相关文章候选
+- **THEN** 每个标签并发请求最多 10 篇候选文章
+- **AND** `selectRelatedPosts` 排除当前文章编号并按共享标签数降序、更新时间降序、编号升序排序
+- **AND** 同一编号仅保留第一条，总数不超过 3 篇
+- **AND** 无标签或全部请求失败时返回空数组
+
+### Requirement: 文章标签链接指向站内主题页
+- **GIVEN** 文章详情页渲染标签
+- **WHEN** 生成标签链接
+- **THEN** 使用 `buildTopicUrl(label.name)` 生成 `/topics/<encoded>` 站内链接
+- **AND** 不再构造 GitHub Issue label query URL
+
+### Requirement: Alert 区分站内外链接的打开行为
+- **GIVEN** Alert 组件渲染带链接的内容
+- **WHEN** 链接 href 是外部域名
+- **THEN** 设置 `target="_blank"` 与 `rel="noopener noreferrer"`
+- **WHEN** 链接 href 是站内路径
+- **THEN** 不设置 `target="_blank"`，保持同窗口导航

--- a/openspec/specs/build-config/spec.md
+++ b/openspec/specs/build-config/spec.md
@@ -36,3 +36,35 @@
 - **GIVEN** Next.js 服务运行在生产环境且未显式配置 `NEST_API_URL`
 - **WHEN** Server Component 或 Route Handler 通过共享 service 请求 Nest API
 - **THEN** 默认 API base 应为 `http://nest:3200/v2`
+
+### Requirement: Dockerfile 支持 Console 构建
+Dockerfile SHALL 提供 deps、builder 和 runner 阶段以构建 Console 静态镜像。
+
+#### Scenario: Console 多阶段构建
+- **GIVEN** pnpm workspace 中包含 `packages/wuh.site.console`
+- **WHEN** 执行 Docker 构建
+- **THEN** deps 阶段复制 Console `package.json` 并安装 workspace 依赖
+- **AND** builder-console 阶段执行 `pnpm run build:console`
+- **AND** runner-console 阶段使用 `nginx:alpine` 提供静态文件服务
+
+### Requirement: Docker Compose 包含 Console 服务
+Docker Compose 配置 SHALL 定义生产与 staging Console 服务。
+
+#### Scenario: 生产与 staging 端口规划
+- **GIVEN** Compose 文件包含 next、nest、console 服务
+- **WHEN** 启动生产容器
+- **THEN** console 绑定 `127.0.0.1:3300`
+- **WHEN** 启动 staging 容器
+- **THEN** console staging 绑定 `127.0.0.1:3301`、nest staging 绑定 `127.0.0.1:3201`、next staging 绑定 `127.0.0.1:3001`
+
+### Requirement: 部署脚本管理 Console 生命周期
+`deploy-docker.sh` SHALL 为 Console 提供 build、staging health、switch、diagnose、cancel 和 rollback 能力。
+
+#### Scenario: deploy-docker.sh Console 命令
+- **GIVEN** 部署脚本已扩展 Console 支持
+- **WHEN** 执行 `build-console`
+- **THEN** 构建 Console 镜像
+- **WHEN** 执行 `diagnose`
+- **THEN** 包含 Console 容器状态检查
+- **WHEN** 执行 `cancel`
+- **THEN** 清理 staging Console 容器


### PR DESCRIPTION
## 变更

将 `docs/superpowers/` 中的实施计划与设计文档转换为 OpenSpec 规范，归档并同步 canonical specs。

### SEO 内容发现与站内导航
- 合并 8 份 SEO P0–P1.7 实施计划为一个变更
- 涉及领域: `seo` (13 条新需求), `blog-detail` (3 条新需求)
- 已归档的相关阅读索引设计不重复迁移

### Console 生产部署
- 补齐原有 proposals 骨架的 design、tasks 和两组 delta spec
- 涉及领域: `admin-console` (10 条), `build-config` (3 条)

### 规范同步
- 四个 canonical spec 文件合并增量需求
- `openspec/INDEX.md` 关键词与需求列表同步更新