### PR TITLE
fix(about): route heatmap requests through API proxy

### DIFF
--- a/packages/wuh.site.next/app/about/AboutView.tsx
+++ b/packages/wuh.site.next/app/about/AboutView.tsx
@@ -68,7 +68,7 @@ const AboutView = ({ profile, repos: _ }: AboutViewProps) => {
 
   const { data: heatmapData, loading: heatmapLoading, error: heatmapError } = useRequest<HeatmapData>(
     async () => {
-      const res = await fetch('/v2/github/contributions?username=stack-wuh')
+      const res = await fetch('/api/v2/github/contributions?username=stack-wuh')
       if (!res.ok) throw new Error('Failed to fetch')
       return res.json()
     },
@@ -77,7 +77,7 @@ const AboutView = ({ profile, repos: _ }: AboutViewProps) => {
 
   const { data: activityData, loading: activityLoading, error: activityError } = useRequest<SiteActivityHeatmap>(
     async () => {
-      const res = await fetch('/v2/about/activity')
+      const res = await fetch('/api/v2/about/activity')
       if (!res.ok) throw new Error('Failed to fetch site activity')
       return res.json()
     },


### PR DESCRIPTION
## Summary
- 修复 About 页面 GitHub 贡献热力图请求路径
- 修复 About 页面站点活动热力图请求路径
- 通过 Next.js 已配置的 /api/* rewrite 转发到 NestJS v2 API

## Root cause
页面请求使用 /v2/*，未经过 Next.js 的 /api/:path* rewrite，导致两个接口返回 404。

## Verification
- API 路径静态检查：通过
- git diff --check：通过
- 端到端请求：未完成；本地 NestJS 未启动，代理请求返回 500
- pnpm install --frozen-lockfile：环境 SIGSEGV，无法在 worktree 安装依赖
- worktree 内 oxlint：不可用，依赖未安装

本 PR 仅修复请求路径，不自动合并。