### PR TITLE
fix(hooks): 修复客户端服务响应解包

### DIFF
--- a/packages/hooks/useFetch/createService.ts
+++ b/packages/hooks/useFetch/createService.ts
@@ -70,6 +70,15 @@ type UseCallOptions<TQuery, TBody> = {
   onError?: (error: FetchError) => void
 }
 
+type ClientResult<TResponse> = Pick<FetchResult<TResponse>, 'data' | 'error'>
+
+export function resolveClientResult<TResponse>(result?: FetchResult<TResponse>): ClientResult<TResponse> {
+  return {
+    data: result?.data ?? null,
+    error: result?.error ?? null,
+  }
+}
+
 function createUseHook<TResponse, TQuery = Record<string, unknown>, TBody = unknown>(
   endpoint: EndpointDef,
   globalOnError?: (error: FetchError) => void
@@ -80,22 +89,25 @@ function createUseHook<TResponse, TQuery = Record<string, unknown>, TBody = unkn
 
     const onError = localOnError || globalOnError
 
-    const result = useRequest<TResponse, []>(
+    const result = useRequest<FetchResult<TResponse>, []>(
       () =>
         fetcher<TResponse>(url, {
           method: endpoint.method,
           headers: { 'Accept': 'application/json', ...headers },
           query: query as QueryRecord,
           body,
-        }) as Promise<TResponse>,
+        }),
       {
-        onError: (e) => onError?.(e as unknown as FetchError),
+        onSuccess: (response) => {
+          if (response.error) onError?.(response.error)
+        },
       }
     )
+    const clientResult = resolveClientResult(result.data)
 
     return {
-      data: result.data ?? null,
-      error: (result.error as unknown as FetchError) ?? null,
+      data: clientResult.data,
+      error: clientResult.error ?? ((result.error as unknown as FetchError) || null),
       loading: result.loading,
       run: result.run,
       refresh: result.refresh,


### PR DESCRIPTION
## 问题

最近的首屏性能提交将首页部分请求迁移到客户端后，`createService` 将 `Promise<FetchResult<T>>` 错误断言为 `Promise<T>`。调用方拿到整个请求包装对象而非业务响应，可能在首页触发 `.filter is not a function` / `.map is not a function`。

## 修复

- 按真实的 `FetchResult<TResponse>` 类型接收客户端请求结果
- 向业务组件返回解包后的 `data`
- 暴露 API 错误并继续触发全局或局部 `onError`

## 验证

- API Base 测试通过
- 首屏边界测试 6/6 通过
- `git diff --check` 通过
- 本机 `tsc --noEmit` 与 Next.js build 被 SIGSEGV/exit 139 阻断，需依赖 CI 继续验证