### PR TITLE
feat(seo): 全站统一吴尒红（Shadow）个人品牌 (#300)

### DIFF
--- a/packages/wuh.site.next/app/about/layout.tsx
+++ b/packages/wuh.site.next/app/about/layout.tsx
@@ -5,11 +5,11 @@ const SITE_URL = 'https://wuh.site'
 
 export const metadata: Metadata = {
   title: '关于',
-  description: '数据驱动的作者日记，以 GitHub 热力图为灵感，汇聚创作故事',
+  description: '吴尒红（Shadow）的创作档案，以数据记录思考、作品与知识系统',
   alternates: { canonical: `${SITE_URL}/about` },
   openGraph: {
     title: '关于',
-    description: '数据驱动的作者日记，以 GitHub 热力图为灵感',
+    description: '吴尒红（Shadow）的创作档案，以数据记录思考与作品',
     url: `${SITE_URL}/about`,
     siteName: 'wuh.site',
     type: 'website',

--- a/packages/wuh.site.next/app/about/page.tsx
+++ b/packages/wuh.site.next/app/about/page.tsx
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
   alternates: { canonical: `${SITE_URL}/about` },
   openGraph: {
     title: '关于',
-    description: '输出节奏总览 — 记录思考，串联碎片，构建自己的知识系统',
+    description: '吴尒红（Shadow）的创作节奏总览，记录思考、串联碎片并构建知识系统',
     url: `${SITE_URL}/about`,
     siteName: 'wuh.site',
     type: 'website',

--- a/packages/wuh.site.next/app/blog/page.tsx
+++ b/packages/wuh.site.next/app/blog/page.tsx
@@ -13,8 +13,8 @@ export async function generateMetadata({ searchParams }: { searchParams?: BlogSe
   const currentPage = toPageNumber(resolvedSearchParams?.page)
   const canonicalPath = currentPage > 1 && !hasActiveLabels ? `/blog?page=${currentPage}` : '/blog'
   const description = hasActiveLabels
-    ? `筛选 wuh.site 中与「${activeLabels.join('、')}」相关的博客文章。`
-    : '收录 GitHub Issues 中的全部博客文章'
+    ? `阅读吴尒红（Shadow）与「${activeLabels.join('、')}」相关的博客文章。`
+    : '阅读吴尒红（Shadow）关于前端工程、开源项目与设计系统的技术文章'
   const robots = hasActiveLabels
     ? { index: false, follow: true }
     : { index: true, follow: true }

--- a/packages/wuh.site.next/app/footprint/layout.tsx
+++ b/packages/wuh.site.next/app/footprint/layout.tsx
@@ -5,11 +5,11 @@ const SITE_URL = 'https://wuh.site'
 
 export const metadata: Metadata = {
   title: '足迹',
-  description: '深圳周边的旅游足迹记录，探索路线与风景',
+  description: '吴尒红（Shadow）记录的深圳周边旅游足迹、探索路线与沿途风景',
   alternates: { canonical: `${SITE_URL}/footprint` },
   openGraph: {
     title: '足迹',
-    description: '深圳周边的旅游足迹记录',
+    description: '吴尒红（Shadow）记录的深圳周边旅游足迹与沿途风景',
     url: `${SITE_URL}/footprint`,
     siteName: 'wuh.site',
     type: 'website',
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary',
     title: '足迹',
-    description: '深圳周边的旅游足迹记录',
+    description: '吴尒红（Shadow）记录的深圳周边旅游足迹与沿途风景',
   },
 }
 

--- a/packages/wuh.site.next/app/guestbook/page.tsx
+++ b/packages/wuh.site.next/app/guestbook/page.tsx
@@ -4,7 +4,7 @@ import GuestbookPageView from './GuestbookPageView'
 
 export const metadata: Metadata = {
   title: '留言板 - wuh.site',
-  description: '来这里留下你的足迹，说点什么都好。',
+  description: '在吴尒红（Shadow）的个人站留下足迹，分享想法与问候。',
 }
 
 const GUESTBOOK_ISSUE_NUMBER = 999999

--- a/packages/wuh.site.next/app/layout.tsx
+++ b/packages/wuh.site.next/app/layout.tsx
@@ -25,7 +25,7 @@ const notoSerifSC = Noto_Serif_SC({
   display: 'swap',
 })
 
-const siteDescription = '记录前端工程、开源项目、设计系统与个人思考。'
+const siteDescription = '吴尒红（Shadow）的个人站，记录前端工程、开源项目、设计系统与个人思考。'
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://wuh.site'),
@@ -34,8 +34,8 @@ export const metadata: Metadata = {
     template: '%s · wuh.site',
   },
   description: siteDescription,
-  authors: [{ name: 'shadow', url: 'https://github.com/stack-wuh' }],
-  creator: 'shadow',
+  authors: [{ name: '吴尒红（Shadow）', url: 'https://github.com/stack-wuh' }],
+  creator: '吴尒红（Shadow）',
   publisher: 'wuh.site',
   robots: { index: true, follow: true },
   openGraph: {

--- a/packages/wuh.site.next/app/lib/seo.ts
+++ b/packages/wuh.site.next/app/lib/seo.ts
@@ -5,7 +5,7 @@ export const SITE_URL = 'https://wuh.site'
 export const GITHUB_PROFILE_URL = 'https://github.com/stack-wuh'
 export const SITE_PERSON_ID = `${SITE_URL}/about#person`
 export const DEFAULT_OG_IMAGE_PATH = '/og-default.png'
-export const DEFAULT_ARTICLE_DESCRIPTION = '阅读这篇博客文章'
+export const DEFAULT_ARTICLE_DESCRIPTION = '吴尒红（Shadow）的技术文章'
 
 type ArticleIssue = {
   number: number

--- a/packages/wuh.site.next/app/lib/structured-data.ts
+++ b/packages/wuh.site.next/app/lib/structured-data.ts
@@ -1,6 +1,8 @@
 const SITE_URL = 'https://wuh.site'
 const PERSON_URL = `${SITE_URL}/about`
+const PERSON_NAME = '吴尒红（Shadow）'
 const PERSON_ID = `${PERSON_URL}#person`
+const GITHUB_PROFILE_URL = 'https://github.com/stack-wuh'
 
 type JsonLdRecord = Record<string, unknown>
 
@@ -25,8 +27,9 @@ function createAuthorReference(): JsonLdRecord {
   return {
     '@type': 'Person',
     '@id': PERSON_ID,
-    name: 'shadow',
+    name: PERSON_NAME,
     url: PERSON_URL,
+    sameAs: [GITHUB_PROFILE_URL],
   }
 }
 
@@ -43,14 +46,14 @@ export function createSiteStructuredData(): JsonLdRecord {
         '@id': `${SITE_URL}/#website`,
         url: SITE_URL,
         name: 'wuh.site',
-        description: '记录前端工程、开源项目、设计系统与个人思考。',
+        description: '吴尒红（Shadow）的个人站，记录前端工程、开源项目、设计系统与个人思考。',
         inLanguage: 'zh-CN',
         publisher: { '@id': PERSON_ID },
       },
       {
         '@type': 'Person',
         '@id': PERSON_ID,
-        name: 'shadow',
+        name: PERSON_NAME,
         url: PERSON_URL,
         sameAs: ['https://github.com/stack-wuh'],
       },

--- a/packages/wuh.site.next/app/page.tsx
+++ b/packages/wuh.site.next/app/page.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
   alternates: { canonical: SITE_URL },
   openGraph: {
     title: '朝朝如念',
-    description: '基于 Next.js 的个人站，汇集 GitHub 项目、文章与工具',
+    description: '吴尒红（Shadow）的个人站，汇集前端工程、GitHub 开源项目、技术文章与工具',
     url: SITE_URL,
     siteName: 'wuh.site',
     type: 'website',
@@ -27,7 +27,7 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary',
     title: '朝朝如念',
-    description: '基于 Next.js 的个人站，汇集 GitHub 项目、文章与工具',
+    description: '吴尒红（Shadow）的个人站，汇集前端工程、GitHub 开源项目、技术文章与工具',
   },
 }
 

--- a/packages/wuh.site.next/app/topics/[label]/page.tsx
+++ b/packages/wuh.site.next/app/topics/[label]/page.tsx
@@ -50,7 +50,7 @@ export async function generateMetadata({ params }: { params: Promise<TopicPagePa
   const { label: rawLabel } = await params
   const label = decodeTopicParam(rawLabel)
   const title = `${label} 相关文章`
-  const description = `阅读 wuh.site 中与「${label}」相关的文章。`
+  const description = `阅读吴尒红（Shadow）与「${label}」相关的文章。`
   const url = `${SITE_URL}${buildTopicUrl(label)}`
 
   return {
@@ -80,7 +80,7 @@ export default async function TopicPage({ params }: { params: Promise<TopicPageP
   const collectionJsonLd = createCollectionPageStructuredData({
     url,
     name: `${label} 相关文章`,
-    description: `阅读 wuh.site 中与「${label}」相关的文章。`,
+    description: `阅读吴尒红（Shadow）与「${label}」相关的文章。`,
     items: posts.map((post) => ({
       name: post.title,
       url: `${SITE_URL}${buildPostUrl(post.number, post.title)}`,

--- a/packages/wuh.site.next/app/weread/page.tsx
+++ b/packages/wuh.site.next/app/weread/page.tsx
@@ -8,11 +8,11 @@ const PER_PAGE = 10
 
 export const metadata: Metadata = {
   title: '微信读书',
-  description: 'stack-wuh 的微信读书书架',
+  description: '吴尒红（Shadow）的微信读书书架与阅读记录',
   alternates: { canonical: `${SITE_URL}/weread` },
   openGraph: {
     title: '微信读书',
-    description: 'stack-wuh 的微信读书书架',
+    description: '吴尒红（Shadow）的微信读书书架与阅读记录',
     url: `${SITE_URL}/weread`,
     siteName: 'wuh.site',
     type: 'website',

--- a/packages/wuh.site.next/test/seo-personal-brand.test.mjs
+++ b/packages/wuh.site.next/test/seo-personal-brand.test.mjs
@@ -1,0 +1,55 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const personName = '吴尒红（Shadow）'
+
+const indexedMetadataFiles = [
+  'app/layout.tsx',
+  'app/page.tsx',
+  'app/blog/page.tsx',
+  'app/topics/[label]/page.tsx',
+  'app/about/layout.tsx',
+  'app/about/page.tsx',
+  'app/weread/page.tsx',
+  'app/footprint/layout.tsx',
+  'app/guestbook/page.tsx',
+]
+
+test('所有可索引页面 metadata 均包含统一姓名', async () => {
+  const files = await Promise.all(indexedMetadataFiles.map(async (path) => ({
+    path,
+    source: await readFile(resolve(appRoot, path), 'utf8'),
+  })))
+
+  for (const { path, source } of files) {
+    assert.match(source, new RegExp(personName), `${path} 应包含 ${personName}`)
+  }
+})
+
+test('内部 noindex 调试页保持非索引状态', async () => {
+  const source = await readFile(resolve(appRoot, 'app/design/system-color/layout.tsx'), 'utf8')
+  assert.match(source, /robots:\s*\{\s*index:\s*false,\s*follow:\s*false\s*\}/)
+})
+
+test('结构化数据统一作者姓名与 GitHub 身份', async () => {
+  const [structuredData, seo] = await Promise.all([
+    readFile(resolve(appRoot, 'app/lib/structured-data.ts'), 'utf8'),
+    readFile(resolve(appRoot, 'app/lib/seo.ts'), 'utf8'),
+  ])
+
+  assert.match(structuredData, new RegExp(personName))
+  assert.match(seo, new RegExp(personName))
+  assert.match(structuredData, /https:\/\/github\.com\/stack-wuh/)
+  assert.match(seo, /https:\/\/github\.com\/stack-wuh/)
+})
+
+test('文章 description 继续使用内容摘要', async () => {
+  const source = await readFile(resolve(appRoot, 'app/lib/seo.ts'), 'utf8')
+  assert.match(source, /if \(cmsSummary\) return cmsSummary/)
+  assert.match(source, /extractFirstParagraphText\(body\)/)
+  assert.doesNotMatch(source, /buildArticleDescription[\s\S]*?吴尒红（Shadow）[\s\S]*?getArticleKeywords/)
+})


### PR DESCRIPTION
## 变更

- 全站 description 统一使用“吴尒红（Shadow）”，不再仅用 wuh.site / shadow / stack-wuh
- 全局 authors、creator 与 JSON-LD WebSite/Person/ProfilePage/BlogPosting 一致关联吴尒红（Shadow）与 GitHub stack-wuh
- 每个可索引页面保持主题差异化描述，不堆砌关键词
- 文章 description 维持 CMS summary 优先、正文段落回退，不机械追加姓名
- `/design/system-color` 等 noindex 内部调试页不受影响

## 验证

- SEO 个人品牌测试：4/4
- 首屏边界测试：6/6
- API Base 测试：1/1
- `git diff --check` 通过

Closes #300