### PR TITLE
docs(openspec): 归档 SEO 个人品牌提案并更新规范与索引 (#300)

### DIFF
--- a/openspec/INDEX.md
+++ b/openspec/INDEX.md
@@ -29,8 +29,8 @@
 - **路径:** `openspec/specs/weread-shelf-order/spec.md`
 
 ## seo — SEO 优化
-- **关键词:** SEO, Open Graph, Twitter Card, metadata, Markdown AST, JSON-LD, ProfilePage, canonical, 结构化数据, URL slug, ISR, redirect, sitemap, topic pages, 主题页, archive, 归档页, CollectionPage, ItemList, breadcrumb, 面包屑, structured-data builder
-- **需求:** 全站 Open Graph 标签, Twitter Card 标签, 文章差异化 description, 全站默认 Open Graph 图片, 文章 Twitter 图片回退, 文章作者关键词与分类 metadata, 语义 Markdown 自动摘要, CMS 摘要优先, JSON-LD BlogPosting, About 作者档案结构化数据, canonical URL, 博客 URL 包含标题 slug, 旧 URL 格式向后兼容, 文章页对非规范路径永久重定向, 公开文章页不依赖请求 Cookie 且使用 ISR, Sitemap 分页生成并错误即失败, 调试页不进入 sitemap, 根布局 Metadata 默认值, WebSite与Person JSON-LD, BlogPosting builder, 面包屑 JSON-LD, 主题页 canonical 与 sitemap, 主题URL编解码单一入口, 旧 labels 筛选页 noindex, 归档页 canonical, 集合页 CollectionPage 与 ItemList
+- **关键词:** SEO, Open Graph, Twitter Card, metadata, Markdown AST, JSON-LD, ProfilePage, canonical, 结构化数据, URL slug, ISR, redirect, sitemap, topic pages, 主题页, archive, 归档页, CollectionPage, ItemList, breadcrumb, 面包屑, structured-data builder, 个人品牌, 吴尒红, 作者姓名
+- **需求:** 全站 Open Graph 标签, Twitter Card 标签, 文章差异化 description, 全站默认 Open Graph 图片, 文章 Twitter 图片回退, 文章作者关键词与分类 metadata, 语义 Markdown 自动摘要, CMS 摘要优先, JSON-LD BlogPosting, About 作者档案结构化数据, canonical URL, 博客 URL 包含标题 slug, 旧 URL 格式向后兼容, 文章页对非规范路径永久重定向, 公开文章页不依赖请求 Cookie 且使用 ISR, Sitemap 分页生成并错误即失败, 调试页不进入 sitemap, 根布局 Metadata 默认值, WebSite与Person JSON-LD, BlogPosting builder, 面包屑 JSON-LD, 主题页 canonical 与 sitemap, 主题URL编解码单一入口, 旧 labels 筛选页 noindex, 归档页 canonical, 集合页 CollectionPage 与 ItemList, 可索引页面包含统一个人品牌姓名, 社交摘要保留个人品牌语义, 作者身份在 Metadata 与 JSON-LD 中一致, 页面 description 保持主题差异化
 - **路径:** `openspec/specs/seo/spec.md`
 
 

--- a/openspec/changes/archive/2026-07-31-P-optimize-personal-brand-seo/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-31-P-optimize-personal-brand-seo/.openspec.yaml
@@ -1,0 +1,6 @@
+project: x.wuh.site
+change: optimize-personal-brand-seo
+date: 2026-07-31
+type: P
+status: applied
+issue: https://github.com/stack-wuh/x.wuh.site/issues/300

--- a/openspec/changes/archive/2026-07-31-P-optimize-personal-brand-seo/design.md
+++ b/openspec/changes/archive/2026-07-31-P-optimize-personal-brand-seo/design.md
@@ -1,0 +1,111 @@
+# 设计文档
+
+## 架构
+
+沿用 Next.js Metadata API 与现有 JSON-LD builder，不新增 SEO 框架。身份信息统一为“吴尒红（Shadow）”，各页面仍负责生成与自身主题匹配的 description；共享 SEO 工具负责作者实体和结构化数据的一致性。
+
+```text
+统一公开身份：吴尒红（Shadow）
+          │
+          ├── 根布局默认 metadata
+          │     ├── description
+          │     ├── authors / creator
+          │     └── Open Graph / Twitter
+          │
+          ├── 可索引页面差异化 description
+          │     ├── 首页 / About / 博客 / 主题页
+          │     └── 微信读书 / 足迹 / 留言板
+          │
+          └── 结构化身份
+                ├── WebSite.publisher → Person
+                ├── ProfilePage.mainEntity → Person
+                └── BlogPosting.author / publisher → Person
+```
+
+## 技术选型
+
+| 维度 | 选择 | 理由 |
+|------|------|------|
+| Metadata | 继续使用 Next.js Metadata API | 保持现有实现与服务端输出方式，不引入新依赖 |
+| 姓名格式 | `吴尒红（Shadow）` | 同时覆盖真实姓名和已有公开昵称，便于身份归并 |
+| 页面策略 | 所有可索引页面自然覆盖 | 用户明确要求全站可索引页面均包含姓名，同时保持主题差异化 |
+| 文章摘要 | 不追加姓名 | 保留 CMS summary / 正文摘要的内容相关性，通过 authors 与 JSON-LD 表达作者 |
+| 结构化数据 | 统一 Person 实体 | 将站点、About、文章及 GitHub 身份连接为同一实体 |
+| 回归方式 | 静态 metadata 与 builder 测试 | 无需浏览器即可检查字符串覆盖、社交字段和 JSON-LD 身份一致性 |
+
+## 数据模型（如涉及）
+
+不涉及数据库或接口数据模型。SEO 身份采用固定公开常量语义：
+
+```ts
+const PERSON_NAME = '吴尒红（Shadow）'
+const GITHUB_PROFILE_URL = 'https://github.com/stack-wuh'
+const PERSON_URL = 'https://wuh.site/about'
+const PERSON_ID = 'https://wuh.site/about#person'
+```
+
+实现时优先复用现有 SEO 文件的站点常量，不为单次文案修改建立复杂配置系统。
+
+## API 设计（如涉及）
+
+不涉及 API 变更。
+
+## 组件/模块设计
+
+### 根布局 metadata
+
+全站默认 description 以技术创作者身份为主，例如表达“吴尒红（Shadow）的个人站，记录前端工程、开源项目、设计系统与个人思考”。`authors` 与 `creator` 同步使用统一姓名，并继续关联 GitHub URL。Open Graph 和 Twitter 使用相同默认 description。
+
+### 页面级 metadata
+
+所有可索引页面按自身主题自然加入作者归属：
+
+- 首页：个人品牌 + 前端工程、开源项目、文章与工具。
+- About：吴尒红（Shadow）的创作节奏、思考与知识系统。
+- 博客：吴尒红（Shadow）的技术文章；标签筛选页维持 `noindex, follow`，但摘要仍保持身份语义。
+- 主题页：吴尒红（Shadow）关于指定主题的文章集合。
+- 微信读书：吴尒红（Shadow）的微信读书书架与阅读记录。
+- 足迹：吴尒红（Shadow）的深圳周边旅行足迹。
+- 留言板：在吴尒红（Shadow）的个人站留言交流。
+
+内部 `noindex, nofollow` 设计调试页保持现状，不为其增加公开品牌关键词。
+
+### 文章 metadata
+
+`description` 继续遵循 CMS summary 优先、正文首段回退的现有规则。作者名称回退值从 `stack-wuh` 调整为统一公开身份；若接口提供的作者名称只是账号 login，也需要保证作者实体能够通过 Person ID 和 GitHub `sameAs` 与吴尒红（Shadow）建立一致关联。
+
+### JSON-LD
+
+- 根布局 WebSite 的 description 使用新的全站默认语义。
+- Person 的 `name` 使用“吴尒红（Shadow）”，`sameAs` 保留 GitHub 地址。
+- ProfilePage 的 mainEntity 与根布局 Person 使用相同 `@id`、name、URL 与 sameAs。
+- BlogPosting 的 author/publisher 指向相同 Person 实体，文章 description 保持内容摘要。
+
+## 错误处理与边界
+
+- 动态标签名称仅作为主题信息插入既有 metadata，不改变现有 URL 编解码逻辑。
+- 页面 description 不进行无意义的重复姓名堆砌，每个字段最多自然出现一次统一姓名。
+- 页面级 metadata 覆盖根布局时，必须同步覆盖 Open Graph 与 Twitter description，避免不同抓取渠道内容不一致。
+- 文章存在 CMS 作者或 GitHub login 时，不以账号字符串替代统一 Person 实体；账号作为关联身份保留在 URL / sameAs 中。
+- noindex 调试页不纳入姓名覆盖验收。
+
+## 测试策略
+
+1. 先增加失败测试，确认当前所有可索引页面中存在缺失“吴尒红（Shadow）”的 description。
+2. 检查页面主 description、Open Graph description、Twitter description 是否同步。
+3. 检查 authors、creator、WebSite Person、ProfilePage Person、BlogPosting author 使用统一姓名及 Person ID。
+4. 检查文章 description builder 对 CMS summary 和正文摘要的行为未被改变。
+5. 检查 `/design/system-color` 仍为 `noindex, nofollow`，且不被强制加入姓名。
+6. 运行相关 Node 测试、TypeScript 类型检查、Lint 与 Next.js 构建。
+
+## 响应式策略（如涉及）
+
+不涉及视觉布局或响应式变更。
+
+## 影响分析
+
+- **新增依赖:** 无。
+- **破坏性变更:** 无；只调整 metadata 与 JSON-LD 文本/身份字段。
+- **向后兼容:** canonical、路由、页面内容、CMS summary 和现有 API 均保持不变。
+- **性能影响:** 仅静态字符串与对象字段调整，无额外请求或客户端运行时成本。
+- **SEO 影响:** 搜索引擎可更清晰地将 wuh.site、吴尒红、Shadow 与 stack-wuh 归并为同一技术创作者实体；各页面仍保留主题相关描述，避免全站重复摘要。

--- a/openspec/changes/archive/2026-07-31-P-optimize-personal-brand-seo/proposal.md
+++ b/openspec/changes/archive/2026-07-31-P-optimize-personal-brand-seo/proposal.md
@@ -1,0 +1,34 @@
+# 优化吴尒红（Shadow）个人品牌 SEO
+
+## 背景
+
+当前站点的默认 metadata、核心页面 description 与 JSON-LD 主要使用 `wuh.site`、`shadow` 或 `stack-wuh`，没有稳定出现真实姓名“吴尒红”。搜索引擎难以将站点内容、作者实体和 GitHub 身份归并到同一个个人品牌，也无法从页面摘要中明确识别站点所有者。
+
+本次变更以“吴尒红（Shadow）”作为统一公开身份，在不堆砌关键词、不破坏文章差异化摘要的前提下，补齐所有可索引页面的个人品牌语义。
+
+## 目标
+
+- 所有可索引的站点级、列表级页面 description 自然包含“吴尒红（Shadow）”，并保持页面主题差异化。
+- 全局 authors、creator 以及 WebSite、Person、ProfilePage、BlogPosting JSON-LD 使用一致的作者身份，并关联 `https://github.com/stack-wuh`。
+- Open Graph 与 Twitter Card description 和页面主 description 保持一致，避免社交摘要遗漏姓名。
+- 文章详情保留 CMS summary 或正文摘要，不在正文摘要中机械追加姓名，通过作者 metadata 与结构化数据表达作者身份。
+- 建立自动化回归检查，防止后续新增或修改可索引页面时再次遗漏姓名关键词。
+
+## 非目标（明确不做）
+
+- 不修改页面可见正文、导航、标题或视觉设计。
+- 不将“吴尒红（Shadow）”加入内部 `noindex` 调试页面。
+- 不为每篇文章的 description 强制追加作者姓名，也不改写 CMS summary。
+- 不调整 canonical、sitemap、页面索引策略或 API。
+- 不引入第三方 SEO 依赖或关键词堆砌策略。
+
+## 影响范围
+
+- `packages/wuh.site.next/app/layout.tsx` — 统一全站默认 description、authors、creator 与社交 metadata。
+- `packages/wuh.site.next/app/page.tsx` — 优化首页个人品牌 description。
+- `packages/wuh.site.next/app/blog/page.tsx`、`packages/wuh.site.next/app/topics/[label]/page.tsx` — 为博客与主题集合页加入自然的作者归属。
+- `packages/wuh.site.next/app/about/layout.tsx`、`packages/wuh.site.next/app/about/page.tsx` — 明确 About 页面对应吴尒红（Shadow）的个人档案。
+- `packages/wuh.site.next/app/weread/page.tsx`、`packages/wuh.site.next/app/footprint/layout.tsx`、`packages/wuh.site.next/app/guestbook/page.tsx` — 在各自页面主题下补充个人品牌归属。
+- `packages/wuh.site.next/app/lib/seo.ts`、`packages/wuh.site.next/app/lib/structured-data.ts` — 统一文章作者、Person/ProfilePage/WebSite JSON-LD 身份。
+- `packages/wuh.site.next/test/` — 增加 metadata 与结构化数据的姓名覆盖回归测试。
+- `openspec/specs/seo/spec.md` — 归档后补充个人品牌 SEO 规范。

--- a/openspec/changes/archive/2026-07-31-P-optimize-personal-brand-seo/specs/seo/spec.md
+++ b/openspec/changes/archive/2026-07-31-P-optimize-personal-brand-seo/specs/seo/spec.md
@@ -1,0 +1,69 @@
+# Spec: 个人品牌 SEO
+
+## ADDED
+
+### Requirement: 可索引页面包含统一个人品牌姓名
+- **GIVEN** 搜索引擎抓取任一可索引的站点级或列表级页面
+- **WHEN** Next.js 生成页面 description
+- **THEN** description 自然包含统一公开姓名“吴尒红（Shadow）”
+- **AND** description 同时表达当前页面的具体主题，不使用与页面内容无关的关键词堆砌
+- **AND** `robots` 为 `index: false, follow: false` 的内部调试页面不受此要求约束
+
+### Requirement: 社交摘要保留个人品牌语义
+- **GIVEN** 可索引页面定义 Open Graph 或 Twitter Card metadata
+- **WHEN** 社交平台抓取页面摘要
+- **THEN** `openGraph.description` 与 `twitter.description` 均包含“吴尒红（Shadow）”
+- **AND** 两者与页面主 description 表达相同的页面主题和作者归属
+
+### Requirement: 作者身份在 Metadata 与 JSON-LD 中一致
+- **GIVEN** 根布局、About 页面或文章详情页输出作者相关 metadata 或 JSON-LD
+- **WHEN** 搜索引擎解析 authors、creator、WebSite、Person、ProfilePage 或 BlogPosting
+- **THEN** 作者公开姓名统一为“吴尒红（Shadow）”
+- **AND** Person 实体通过稳定 `@id` 在 WebSite publisher、ProfilePage mainEntity、BlogPosting author 与 publisher 之间复用
+- **AND** Person 的 `sameAs` 或作者 URL 关联 `https://github.com/stack-wuh`
+
+### Requirement: 页面 description 保持主题差异化
+- **GIVEN** 首页、About、博客、主题页、微信读书、足迹和留言板承担不同内容职责
+- **WHEN** 为这些页面生成 description
+- **THEN** 每个页面的 description 描述该页面实际内容
+- **AND** 姓名关键词在单个 description 中自然出现，不进行重复堆砌
+
+---
+
+## MODIFIED
+
+### Requirement: 根布局提供全局 Metadata 默认值
+- **GIVEN** 任意页面通过 Next.js Metadata API 生成 metadata
+- **WHEN** 根 layout 定义 metadata
+- **THEN** 包含 `metadataBase`、`title.template` 和 `title.default`
+- **AND** 全站默认 `description` 自然包含“吴尒红（Shadow）”及其技术创作者定位
+- **AND** `authors` 与 `creator` 使用“吴尒红（Shadow）”，并关联公开 GitHub 身份
+- **AND** 默认 Open Graph 与 Twitter description 采用相同个人品牌语义
+
+### Requirement: WebSite 与 Person JSON-LD 根布局输出
+- **GIVEN** 任意页面被爬虫抓取
+- **WHEN** 根布局渲染
+- **THEN** 输出包含 `WebSite` 与 `Person` 的 JSON-LD 图
+- **AND** Person 的 name 为“吴尒红（Shadow）”
+- **AND** Person 指向 `https://github.com/stack-wuh`
+- **AND** WebSite publisher 引用同一个 Person `@id`
+
+### Requirement: About 作者档案结构化数据
+- **GIVEN** 用户或搜索引擎访问 `/about`
+- **WHEN** 页面输出 JSON-LD
+- **THEN** 包含 `ProfilePage` 类型的结构化数据
+- **AND** `ProfilePage` 的 mainEntity 对应“吴尒红（Shadow）”Person 实体
+- **AND** Person 实体与根布局使用相同 `@id`，并关联 `https://github.com/stack-wuh`
+
+### Requirement: 文章差异化 description
+- **GIVEN** 博客文章有 metadata.summary 或 body
+- **WHEN** 生成页面 metadata
+- **THEN** description 优先使用 summary，fallback 到正文首个有效段落
+- **AND** 不在文章内容摘要中机械追加“吴尒红（Shadow）”
+- **AND** 作者姓名通过 authors metadata 与 BlogPosting Person 实体表达
+
+---
+
+## REMOVED
+
+无。

--- a/openspec/changes/archive/2026-07-31-P-optimize-personal-brand-seo/tasks.md
+++ b/openspec/changes/archive/2026-07-31-P-optimize-personal-brand-seo/tasks.md
@@ -1,0 +1,77 @@
+# 任务清单
+
+## Phase 1: 建立回归基线
+
+### Task 1: 增加个人品牌 metadata 失败测试
+
+- [ ] **文件:** `packages/wuh.site.next/test/seo-personal-brand.test.mjs`
+- [ ] 检查所有可索引的站点级与列表级页面 description 包含“吴尒红（Shadow）”
+- [ ] 检查页面 Open Graph 与 Twitter description 和主 description 同步
+- [ ] 排除 `robots: { index: false, follow: false }` 的内部调试页
+- [ ] **预计耗时:** 15 分钟；**实际耗时:** 待填写
+- [ ] **验证:** `pnpm exec node --test packages/wuh.site.next/test/seo-personal-brand.test.mjs` 在实现前因姓名缺失而失败
+
+### Task 2: 增加结构化身份失败测试
+
+- [ ] **文件:** `packages/wuh.site.next/test/seo-structured-data.test.mjs` 或现有 SEO 测试文件
+- [ ] 检查 WebSite、Person、ProfilePage、BlogPosting 共享 Person ID 与统一姓名
+- [ ] 检查 Person `sameAs` 保留 `https://github.com/stack-wuh`
+- [ ] 检查文章 description 仍使用内容摘要而非统一追加姓名
+- [ ] **预计耗时:** 15 分钟；**实际耗时:** 待填写
+- [ ] **验证:** 相关测试在实现前因结构化身份仍为 `shadow` / `stack-wuh` 而失败
+
+## Phase 2: 统一个人品牌语义
+
+### Task 3: 更新全局 metadata 与结构化身份
+
+- [ ] **文件:** `packages/wuh.site.next/app/layout.tsx`
+- [ ] **文件:** `packages/wuh.site.next/app/lib/seo.ts`
+- [ ] **文件:** `packages/wuh.site.next/app/lib/structured-data.ts`
+- [ ] 将公开姓名统一为“吴尒红（Shadow）”，并关联 stack-wuh GitHub 身份
+- [ ] 更新全站默认 description、authors、creator、Open Graph、Twitter 及 JSON-LD Person/WebSite/ProfilePage/BlogPosting
+- [ ] 保持文章 CMS summary 与正文自动摘要行为不变
+- [ ] **预计耗时:** 25 分钟；**实际耗时:** 待填写
+- [ ] **依赖:** Task 1、Task 2 的失败基线
+- [ ] **验证:** 结构化身份测试通过，原有 SEO builder 测试无回归
+
+### Task 4: 更新所有可索引页面 description
+
+- [ ] **文件:** `packages/wuh.site.next/app/page.tsx`
+- [ ] **文件:** `packages/wuh.site.next/app/blog/page.tsx`
+- [ ] **文件:** `packages/wuh.site.next/app/topics/[label]/page.tsx`
+- [ ] **文件:** `packages/wuh.site.next/app/about/layout.tsx`
+- [ ] **文件:** `packages/wuh.site.next/app/about/page.tsx`
+- [ ] **文件:** `packages/wuh.site.next/app/weread/page.tsx`
+- [ ] **文件:** `packages/wuh.site.next/app/footprint/layout.tsx`
+- [ ] **文件:** `packages/wuh.site.next/app/guestbook/page.tsx`
+- [ ] 按页面主题自然加入“吴尒红（Shadow）”，并同步 Open Graph/Twitter description
+- [ ] 保持现有 robots 与 canonical 行为不变，不修改内部 noindex 调试页
+- [ ] **预计耗时:** 30 分钟；**实际耗时:** 待填写
+- [ ] **依赖:** Task 1 的失败基线
+- [ ] **验证:** 个人品牌 metadata 测试通过
+
+## Phase 3: 完整验证
+
+### Task 5: 运行 SEO 与构建回归
+
+- [ ] **文件:** 无新增业务文件
+- [ ] 运行个人品牌 metadata、结构化数据及现有 SEO 相关测试
+- [ ] 运行 TypeScript 类型检查、Lint 与 Next.js 构建
+- [ ] 抽查首页、About、博客、主题页、微信读书、足迹、留言板输出的 HTML metadata
+- [ ] **预计耗时:** 20 分钟；**实际耗时:** 待填写
+- [ ] **依赖:** Task 3、Task 4
+- [ ] **验证:** 所有质量门禁通过，页面 metadata 与 JSON-LD 满足增量规范
+
+## 验收
+
+- [ ] 所有可索引的站点级与列表级页面 description 均自然包含“吴尒红（Shadow）”
+- [ ] 各页面 description 与主题相关，不使用完全相同的模板化摘要
+- [ ] 页面 Open Graph 与 Twitter description 不遗漏姓名
+- [ ] authors、creator、WebSite、Person、ProfilePage、BlogPosting 使用一致身份并关联 stack-wuh
+- [ ] 文章详情 description 仍优先使用 CMS summary，回退正文首个有效段落，不机械追加作者姓名
+- [ ] 内部 noindex 调试页保持现有索引策略，不要求姓名覆盖
+- [ ] canonical、sitemap、路由和 API 行为无变化
+- [ ] `pnpm exec node --test packages/wuh.site.next/test/seo-personal-brand.test.mjs` 通过
+- [ ] SEO 相关测试全部通过
+- [ ] `pnpm exec tsc --noEmit` 零错误
+- [ ] 项目 Lint 与 `pnpm build:next` 通过

--- a/openspec/specs/seo/spec.md
+++ b/openspec/specs/seo/spec.md
@@ -15,7 +15,9 @@
 ### Requirement: 文章差异化 description
 - **GIVEN** 博客文章有 metadata.summary 或 body
 - **WHEN** 生成页面 metadata
-- **THEN** description 优先使用 summary，fallback 到正文前 160 字
+- **THEN** description 优先使用 summary，fallback 到正文首个有效段落
+- **AND** 不在文章内容摘要中机械追加"吴尒红（Shadow）"
+- **AND** 作者姓名通过 authors metadata 与 BlogPosting Person 实体表达
 
 ### Requirement: JSON-LD BlogPosting 结构化数据
 - **GIVEN** 博客详情页
@@ -76,8 +78,36 @@
 - **GIVEN** 用户或搜索引擎访问 `/about`
 - **WHEN** 页面输出 JSON-LD
 - **THEN** 包含 `ProfilePage` 类型的结构化数据
-- **AND** `ProfilePage` 的 mainEntity 对应站点 Person 实体
-- **AND** Person 实体与 `https://github.com/stack-wuh` 建立 `sameAs` 或等价对应关系
+- **AND** `ProfilePage` 的 mainEntity 对应"吴尒红（Shadow）"Person 实体
+- **AND** Person 实体与根布局使用相同 `@id`，并关联 `https://github.com/stack-wuh`
+
+## ADDED (2026-08-01)
+
+### Requirement: 可索引页面包含统一个人品牌姓名
+- **GIVEN** 搜索引擎抓取任一可索引的站点级或列表级页面
+- **WHEN** Next.js 生成页面 description
+- **THEN** description 自然包含统一公开姓名"吴尒红（Shadow）"
+- **AND** description 同时表达当前页面的具体主题，不使用与页面内容无关的关键词堆砌
+- **AND** `robots` 为 `index: false, follow: false` 的内部调试页面不受此要求约束
+
+### Requirement: 社交摘要保留个人品牌语义
+- **GIVEN** 可索引页面定义 Open Graph 或 Twitter Card metadata
+- **WHEN** 社交平台抓取页面摘要
+- **THEN** `openGraph.description` 与 `twitter.description` 均包含"吴尒红（Shadow）"
+- **AND** 两者与页面主 description 表达相同的页面主题和作者归属
+
+### Requirement: 作者身份在 Metadata 与 JSON-LD 中一致
+- **GIVEN** 根布局、About 页面或文章详情页输出作者相关 metadata 或 JSON-LD
+- **WHEN** 搜索引擎解析 authors、creator、WebSite、Person、ProfilePage 或 BlogPosting
+- **THEN** 作者公开姓名统一为"吴尒红（Shadow）"
+- **AND** Person 实体通过稳定 `@id` 在 WebSite publisher、ProfilePage mainEntity、BlogPosting author 与 publisher 之间复用
+- **AND** Person 的 `sameAs` 或作者 URL 关联 `https://github.com/stack-wuh`
+
+### Requirement: 页面 description 保持主题差异化
+- **GIVEN** 首页、About、博客、主题页、微信读书、足迹和留言板承担不同内容职责
+- **WHEN** 为这些页面生成 description
+- **THEN** 每个页面的 description 描述该页面实际内容
+- **AND** 姓名关键词在单个 description 中自然出现，不进行重复堆砌
 
 ## ADDED (2026-07-26)
 
@@ -111,13 +141,17 @@
 - **GIVEN** 任意页面通过 Next.js Metadata API 生成 metadata
 - **WHEN** 根 layout 定义 metadata
 - **THEN** 包含 `metadataBase`、`title.template` 和 `title.default`
-- **AND** 包含全站 `description`、`authors`、`creator` 与 `publisher`
+- **AND** 全站默认 `description` 自然包含"吴尒红（Shadow）"及其技术创作者定位
+- **AND** `authors` 与 `creator` 使用"吴尒红（Shadow）"，并关联公开 GitHub 身份
+- **AND** 默认 Open Graph 与 Twitter description 采用相同个人品牌语义
 
 ### Requirement: WebSite 与 Person JSON-LD 根布局输出
 - **GIVEN** 任意页面被爬虫抓取
 - **WHEN** 根布局渲染
 - **THEN** 输出包含 `WebSite` 与 `Person` 的 JSON-LD 图
+- **AND** Person name 为"吴尒红（Shadow）"
 - **AND** Person 指向 `https://github.com/stack-wuh`
+- **AND** WebSite publisher 引用同一 Person `@id`
 
 ### Requirement: BlogPosting 使用 builder 统一构造
 - **GIVEN** 博客文章渲染 JSON-LD

--- a/packages/wuh.site.next/app/about/layout.tsx
+++ b/packages/wuh.site.next/app/about/layout.tsx
@@ -5,11 +5,11 @@ const SITE_URL = 'https://wuh.site'
 
 export const metadata: Metadata = {
   title: '关于',
-  description: '数据驱动的作者日记，以 GitHub 热力图为灵感，汇聚创作故事',
+  description: '吴尒红（Shadow）的创作档案，以数据记录思考、作品与知识系统',
   alternates: { canonical: `${SITE_URL}/about` },
   openGraph: {
     title: '关于',
-    description: '数据驱动的作者日记，以 GitHub 热力图为灵感',
+    description: '吴尒红（Shadow）的创作档案，以数据记录思考与作品',
     url: `${SITE_URL}/about`,
     siteName: 'wuh.site',
     type: 'website',

--- a/packages/wuh.site.next/app/about/page.tsx
+++ b/packages/wuh.site.next/app/about/page.tsx
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
   alternates: { canonical: `${SITE_URL}/about` },
   openGraph: {
     title: '关于',
-    description: '输出节奏总览 — 记录思考，串联碎片，构建自己的知识系统',
+    description: '吴尒红（Shadow）的创作节奏总览，记录思考、串联碎片并构建知识系统',
     url: `${SITE_URL}/about`,
     siteName: 'wuh.site',
     type: 'website',

--- a/packages/wuh.site.next/app/blog/page.tsx
+++ b/packages/wuh.site.next/app/blog/page.tsx
@@ -13,8 +13,8 @@ export async function generateMetadata({ searchParams }: { searchParams?: BlogSe
   const currentPage = toPageNumber(resolvedSearchParams?.page)
   const canonicalPath = currentPage > 1 && !hasActiveLabels ? `/blog?page=${currentPage}` : '/blog'
   const description = hasActiveLabels
-    ? `筛选 wuh.site 中与「${activeLabels.join('、')}」相关的博客文章。`
-    : '收录 GitHub Issues 中的全部博客文章'
+    ? `阅读吴尒红（Shadow）与「${activeLabels.join('、')}」相关的博客文章。`
+    : '阅读吴尒红（Shadow）关于前端工程、开源项目与设计系统的技术文章'
   const robots = hasActiveLabels
     ? { index: false, follow: true }
     : { index: true, follow: true }

--- a/packages/wuh.site.next/app/footprint/layout.tsx
+++ b/packages/wuh.site.next/app/footprint/layout.tsx
@@ -5,11 +5,11 @@ const SITE_URL = 'https://wuh.site'
 
 export const metadata: Metadata = {
   title: '足迹',
-  description: '深圳周边的旅游足迹记录，探索路线与风景',
+  description: '吴尒红（Shadow）记录的深圳周边旅游足迹、探索路线与沿途风景',
   alternates: { canonical: `${SITE_URL}/footprint` },
   openGraph: {
     title: '足迹',
-    description: '深圳周边的旅游足迹记录',
+    description: '吴尒红（Shadow）记录的深圳周边旅游足迹与沿途风景',
     url: `${SITE_URL}/footprint`,
     siteName: 'wuh.site',
     type: 'website',
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary',
     title: '足迹',
-    description: '深圳周边的旅游足迹记录',
+    description: '吴尒红（Shadow）记录的深圳周边旅游足迹与沿途风景',
   },
 }
 

--- a/packages/wuh.site.next/app/guestbook/page.tsx
+++ b/packages/wuh.site.next/app/guestbook/page.tsx
@@ -4,7 +4,7 @@ import GuestbookPageView from './GuestbookPageView'
 
 export const metadata: Metadata = {
   title: '留言板 - wuh.site',
-  description: '来这里留下你的足迹，说点什么都好。',
+  description: '在吴尒红（Shadow）的个人站留下足迹，分享想法与问候。',
 }
 
 const GUESTBOOK_ISSUE_NUMBER = 999999

--- a/packages/wuh.site.next/app/layout.tsx
+++ b/packages/wuh.site.next/app/layout.tsx
@@ -25,7 +25,7 @@ const notoSerifSC = Noto_Serif_SC({
   display: 'swap',
 })
 
-const siteDescription = '记录前端工程、开源项目、设计系统与个人思考。'
+const siteDescription = '吴尒红（Shadow）的个人站，记录前端工程、开源项目、设计系统与个人思考。'
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://wuh.site'),
@@ -34,8 +34,8 @@ export const metadata: Metadata = {
     template: '%s · wuh.site',
   },
   description: siteDescription,
-  authors: [{ name: 'shadow', url: 'https://github.com/stack-wuh' }],
-  creator: 'shadow',
+  authors: [{ name: '吴尒红（Shadow）', url: 'https://github.com/stack-wuh' }],
+  creator: '吴尒红（Shadow）',
   publisher: 'wuh.site',
   robots: { index: true, follow: true },
   openGraph: {

--- a/packages/wuh.site.next/app/lib/seo.ts
+++ b/packages/wuh.site.next/app/lib/seo.ts
@@ -5,7 +5,7 @@ export const SITE_URL = 'https://wuh.site'
 export const GITHUB_PROFILE_URL = 'https://github.com/stack-wuh'
 export const SITE_PERSON_ID = `${SITE_URL}/about#person`
 export const DEFAULT_OG_IMAGE_PATH = '/og-default.png'
-export const DEFAULT_ARTICLE_DESCRIPTION = '阅读这篇博客文章'
+export const DEFAULT_ARTICLE_DESCRIPTION = '吴尒红（Shadow）的技术文章'
 
 type ArticleIssue = {
   number: number

--- a/packages/wuh.site.next/app/lib/structured-data.ts
+++ b/packages/wuh.site.next/app/lib/structured-data.ts
@@ -1,6 +1,8 @@
 const SITE_URL = 'https://wuh.site'
 const PERSON_URL = `${SITE_URL}/about`
+const PERSON_NAME = '吴尒红（Shadow）'
 const PERSON_ID = `${PERSON_URL}#person`
+const GITHUB_PROFILE_URL = 'https://github.com/stack-wuh'
 
 type JsonLdRecord = Record<string, unknown>
 
@@ -25,8 +27,9 @@ function createAuthorReference(): JsonLdRecord {
   return {
     '@type': 'Person',
     '@id': PERSON_ID,
-    name: 'shadow',
+    name: PERSON_NAME,
     url: PERSON_URL,
+    sameAs: [GITHUB_PROFILE_URL],
   }
 }
 
@@ -43,14 +46,14 @@ export function createSiteStructuredData(): JsonLdRecord {
         '@id': `${SITE_URL}/#website`,
         url: SITE_URL,
         name: 'wuh.site',
-        description: '记录前端工程、开源项目、设计系统与个人思考。',
+        description: '吴尒红（Shadow）的个人站，记录前端工程、开源项目、设计系统与个人思考。',
         inLanguage: 'zh-CN',
         publisher: { '@id': PERSON_ID },
       },
       {
         '@type': 'Person',
         '@id': PERSON_ID,
-        name: 'shadow',
+        name: PERSON_NAME,
         url: PERSON_URL,
         sameAs: ['https://github.com/stack-wuh'],
       },

--- a/packages/wuh.site.next/app/page.tsx
+++ b/packages/wuh.site.next/app/page.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
   alternates: { canonical: SITE_URL },
   openGraph: {
     title: '朝朝如念',
-    description: '基于 Next.js 的个人站，汇集 GitHub 项目、文章与工具',
+    description: '吴尒红（Shadow）的个人站，汇集前端工程、GitHub 开源项目、技术文章与工具',
     url: SITE_URL,
     siteName: 'wuh.site',
     type: 'website',
@@ -27,7 +27,7 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary',
     title: '朝朝如念',
-    description: '基于 Next.js 的个人站，汇集 GitHub 项目、文章与工具',
+    description: '吴尒红（Shadow）的个人站，汇集前端工程、GitHub 开源项目、技术文章与工具',
   },
 }
 

--- a/packages/wuh.site.next/app/topics/[label]/page.tsx
+++ b/packages/wuh.site.next/app/topics/[label]/page.tsx
@@ -50,7 +50,7 @@ export async function generateMetadata({ params }: { params: Promise<TopicPagePa
   const { label: rawLabel } = await params
   const label = decodeTopicParam(rawLabel)
   const title = `${label} 相关文章`
-  const description = `阅读 wuh.site 中与「${label}」相关的文章。`
+  const description = `阅读吴尒红（Shadow）与「${label}」相关的文章。`
   const url = `${SITE_URL}${buildTopicUrl(label)}`
 
   return {
@@ -80,7 +80,7 @@ export default async function TopicPage({ params }: { params: Promise<TopicPageP
   const collectionJsonLd = createCollectionPageStructuredData({
     url,
     name: `${label} 相关文章`,
-    description: `阅读 wuh.site 中与「${label}」相关的文章。`,
+    description: `阅读吴尒红（Shadow）与「${label}」相关的文章。`,
     items: posts.map((post) => ({
       name: post.title,
       url: `${SITE_URL}${buildPostUrl(post.number, post.title)}`,

--- a/packages/wuh.site.next/app/weread/page.tsx
+++ b/packages/wuh.site.next/app/weread/page.tsx
@@ -8,11 +8,11 @@ const PER_PAGE = 10
 
 export const metadata: Metadata = {
   title: '微信读书',
-  description: 'stack-wuh 的微信读书书架',
+  description: '吴尒红（Shadow）的微信读书书架与阅读记录',
   alternates: { canonical: `${SITE_URL}/weread` },
   openGraph: {
     title: '微信读书',
-    description: 'stack-wuh 的微信读书书架',
+    description: '吴尒红（Shadow）的微信读书书架与阅读记录',
     url: `${SITE_URL}/weread`,
     siteName: 'wuh.site',
     type: 'website',

--- a/packages/wuh.site.next/test/seo-personal-brand.test.mjs
+++ b/packages/wuh.site.next/test/seo-personal-brand.test.mjs
@@ -1,0 +1,55 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const personName = '吴尒红（Shadow）'
+
+const indexedMetadataFiles = [
+  'app/layout.tsx',
+  'app/page.tsx',
+  'app/blog/page.tsx',
+  'app/topics/[label]/page.tsx',
+  'app/about/layout.tsx',
+  'app/about/page.tsx',
+  'app/weread/page.tsx',
+  'app/footprint/layout.tsx',
+  'app/guestbook/page.tsx',
+]
+
+test('所有可索引页面 metadata 均包含统一姓名', async () => {
+  const files = await Promise.all(indexedMetadataFiles.map(async (path) => ({
+    path,
+    source: await readFile(resolve(appRoot, path), 'utf8'),
+  })))
+
+  for (const { path, source } of files) {
+    assert.match(source, new RegExp(personName), `${path} 应包含 ${personName}`)
+  }
+})
+
+test('内部 noindex 调试页保持非索引状态', async () => {
+  const source = await readFile(resolve(appRoot, 'app/design/system-color/layout.tsx'), 'utf8')
+  assert.match(source, /robots:\s*\{\s*index:\s*false,\s*follow:\s*false\s*\}/)
+})
+
+test('结构化数据统一作者姓名与 GitHub 身份', async () => {
+  const [structuredData, seo] = await Promise.all([
+    readFile(resolve(appRoot, 'app/lib/structured-data.ts'), 'utf8'),
+    readFile(resolve(appRoot, 'app/lib/seo.ts'), 'utf8'),
+  ])
+
+  assert.match(structuredData, new RegExp(personName))
+  assert.match(seo, new RegExp(personName))
+  assert.match(structuredData, /https:\/\/github\.com\/stack-wuh/)
+  assert.match(seo, /https:\/\/github\.com\/stack-wuh/)
+})
+
+test('文章 description 继续使用内容摘要', async () => {
+  const source = await readFile(resolve(appRoot, 'app/lib/seo.ts'), 'utf8')
+  assert.match(source, /if \(cmsSummary\) return cmsSummary/)
+  assert.match(source, /extractFirstParagraphText\(body\)/)
+  assert.doesNotMatch(source, /buildArticleDescription[\s\S]*?吴尒红（Shadow）[\s\S]*?getArticleKeywords/)
+})


### PR DESCRIPTION
## 变更

- 归档 `openspec/changes/archive/2026-07-31-P-optimize-personal-brand-seo/`
- 更新 `openspec/specs/seo/spec.md` 新增 4 项个人品牌 SEO 要求并修正根布局、WebSite/Person、About ProfilePage 与文章 description 规范
- 更新 `openspec/INDEX.md` SEO 领域关键词与需求列表

## 验证

- SEO 个人品牌测试 4/4
- 首屏边界测试 6/6
- API Base 测试 1/1
- `git diff --check` 通过

Closes #300