### PR TITLE
fix(next): 恢复访问统计上报组件

### DIFF
--- a/packages/wuh.site.next/components/visit-stats/visit-stats-reporter.tsx
+++ b/packages/wuh.site.next/components/visit-stats/visit-stats-reporter.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import { useEffect } from 'react'
+import { usePathname } from 'next/navigation'
+
+export function VisitStatsReporter() {
+  const pathname = usePathname()
+
+  useEffect(() => {
+    fetch('/api/visit-stats/stats', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: pathname }),
+    }).catch(() => {})
+  }, [pathname])
+
+  return null
+}

--- a/packages/wuh.site.next/test/first-load-boundaries.test.mjs
+++ b/packages/wuh.site.next/test/first-load-boundaries.test.mjs
@@ -37,6 +37,11 @@ test('首页年度总结映射 GitHub 创建时间到视图日期字段', async 
   assert.match(homeView, /created_at:\s*item\.createdAtGitHub/)
 })
 
+test('AppProviders 引用的访问统计上报组件存在', async () => {
+  const reporter = await readFile(resolve(appRoot, 'components/visit-stats/visit-stats-reporter.tsx'), 'utf8')
+  assert.match(reporter, /export function VisitStatsReporter/)
+})
+
 test('博客分类在客户端加载', async () => {
   const blogView = await readFile(resolve(appRoot, 'app/blog/BlogListView.tsx'), 'utf8')
   assert.match(blogView, /contentService\.getLabels/)


### PR DESCRIPTION
## Summary
- 恢复 AppProviders 仍引用的 VisitStatsReporter，修复生产构建 Module not found
- 增加回归测试防止删除仍被引用的组件

## Verification
- 首页/组件回归测试：8/8 通过
- Next lint：通过
- 生产构建：当前环境 SIGSEGV，未能完成本地构建验证

## Root cause
PR #303 误判 VisitStatsReporter 为无引用文件并删除，但 AppProviders 仍保留导入。